### PR TITLE
chore(dev-workflow): bump version to 1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dev-workflow",
       "source": "./plugins/dev-workflow",
       "description": "Reusable dev workflow agents: test running, branch creation, conventional commits, pull request management, and Linear issue management",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "meta-claude",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Dev workflow agents for test running, branch creation, conventional commits, pull request management, and Linear issue management",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Derek DeHart"
   },


### PR DESCRIPTION
## Summary
- Bump dev-workflow plugin version 1.1.0 → 1.1.1

Reflects pr-manager enhancements from PR #10 that were merged without a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)