### PR TITLE
feat(meta-claude): add self-documentation skill for explaining Claude Code features

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,8 +13,8 @@
     {
       "name": "meta-claude",
       "source": "./plugins/meta-claude",
-      "description": "Claude Code productivity skills: session export, transcript management, and self-reflection tools",
-      "version": "1.1.0"
+      "description": "Claude Code productivity skills: session export, self-documentation for explaining features and capabilities, and self-reflection tools",
+      "version": "1.2.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -35,10 +35,22 @@ Dev workflow agents and skills for test running, branch creation, conventional c
 |-------|-------------|
 | `spec-writing` | Interview users to refine rough ideas into comprehensive, implementation-ready specifications |
 
+### meta-claude
+
+Claude Code productivity skills for session management, self-documentation, and self-reflection.
+
+**Skills included:**
+
+| Skill | Description |
+|-------|-------------|
+| `session-export` | Export Claude Code session transcripts from JSONL logs to readable text format |
+| `self-documentation` | Explain Claude Code features, capabilities, and tools; record observations about undocumented behaviors |
+
 ## Usage
 
 Once installed, the agents and skills are automatically available. Claude will proactively use them when you:
 
+**dev-workflow:**
 - Ask to run tests
 - Ask to create a branch
 - Ask to commit changes
@@ -47,8 +59,15 @@ Once installed, the agents and skills are automatically available. Claude will p
 - Ask to verify a deployment or check a live site
 - Ask to write, create, or refine a spec
 
+**meta-claude:**
+- Ask about Claude Code features ("How do skills work?", "What can you do?")
+- Ask decision questions ("Should I use a skill or slash command?")
+- Ask to export a session transcript
+- Report discovering undocumented behavior
+
 ## Updating
 
 ```bash
 /plugin update dev-workflow@ddehart-plugins
+/plugin update meta-claude@ddehart-plugins
 ```

--- a/docs/specs/self-documentation-skill.md
+++ b/docs/specs/self-documentation-skill.md
@@ -1,0 +1,300 @@
+# Self-Documentation Skill Specification
+
+## Overview
+
+A skill for the `meta-claude` plugin that enables Claude Code to explain its own features, guide users through capability decisions, and track undocumented observations discovered through usage.
+
+**Supersedes:** User skill at `~/.claude/skills/claude-code-capabilities/`
+
+**Plugin:** `meta-claude` (version bump required)
+
+## Goals
+
+1. **Answer capability questions** - "How do skills work?", "What can you do?", "What's the difference between X and Y?"
+2. **Guide feature decisions** - "Should I use a skill or slash command?", "When should I use MCP vs plugins?"
+3. **Track release notes** - Maintain index of documented and undocumented features
+4. **Record observations** - Capture user-discovered behaviors not in official docs (e.g., "AskUserQuestion can't be delegated to subagents")
+5. **Enable community contribution** - Create GitHub issues for observations, support PR workflow
+
+## Non-Goals
+
+- Migration from existing user skill (separate concern)
+- Automatic index updates on user machines (updates happen in source repo only)
+- Real-time documentation sync (fetch on demand is sufficient)
+
+## Architecture
+
+### Thematic Reference Structure
+
+Split the ~1,700 lines of reference content into focused files optimized for token efficiency. Only load what's needed for the current question.
+
+```
+plugins/meta-claude/skills/self-documentation/
+├── SKILL.md                           # Main skill definition (~200 lines)
+├── references/
+│   ├── topic-index.md                 # Lightweight keyword → file mapping
+│   ├── decision-guide.md              # "When to use X vs Y" guidance
+│   ├── core-features.md               # Skills, agents, slash commands, hooks
+│   ├── integrations.md                # MCP servers, plugins, IDE extensions
+│   ├── configuration.md               # Settings, permissions, sandboxing, models
+│   ├── workflows.md                   # Git automation, parallel execution
+│   ├── undocumented.md                # Features from release notes without official docs
+│   └── observations.md                # User-discovered behaviors (source of truth for repo)
+```
+
+**Granularity rationale:** ~6-8 thematic files at ~150-250 lines each. Fine enough for targeted loading, coarse enough to avoid excessive file lookups.
+
+### Topic Index
+
+A lightweight file (~50-100 lines) mapping keywords/concepts to reference files:
+
+```markdown
+## Topic Index
+
+| Keywords | Reference File |
+|----------|----------------|
+| skill, skills, SKILL.md, allowed-tools | core-features.md |
+| mcp, server, protocol, tool | integrations.md |
+| permission, sandbox, security | configuration.md |
+| git, branch, commit, pr | workflows.md |
+| should I use, when to use, vs, difference | decision-guide.md |
+| release notes, undocumented, new feature | undocumented.md |
+| observation, discovered, tested, behavior | observations.md |
+```
+
+### Content Distribution
+
+Each thematic reference file contains three tiers of information for its domain:
+
+1. **Documented features** - Official docs URL, key concepts, last verified date
+2. **Undocumented features** - From release notes, what we know, unanswered questions
+3. **Observations** - User-discovered behaviors with reproduction context
+
+This keeps related information co-located rather than requiring multiple file loads.
+
+## Workflows
+
+### Answering Questions
+
+```
+1. Load topic-index.md
+2. Match user question to relevant reference file(s)
+3. Load identified file(s) - may load multiple for cross-theme questions
+4. If needed, fetch official docs via WebFetch
+5. Synthesize conversational response
+6. Update reference file with any new information learned
+```
+
+**Cross-theme questions:** When a question spans multiple themes (e.g., "How do skills work with MCP servers?"), load both relevant files.
+
+**No proactive suggestions:** Answer the question directly without suggesting related topics.
+
+### Recording Observations
+
+When a user discovers undocumented behavior:
+
+```
+1. User reports finding (e.g., "I discovered AskUserQuestion can't be delegated to subagents")
+2. Claude confirms this is a new observation worth recording
+3. Claude proposes creating a GitHub issue
+4. User confirms
+5. Claude creates issue via gh CLI in ddehart/claude-code-plugins
+6. Claude asks user: "Would you also like me to cache this locally and/or create a PR?"
+7. Based on user choice:
+   - Cache locally: Write to ~/.claude/plugin-observations/meta-claude.json
+   - Create PR: Branch, update observations.md, create PR
+   - Neither: Done after issue creation
+```
+
+### Observation Issue Format
+
+Minimal format for GitHub issues:
+
+```markdown
+Title: [Observation] <brief description>
+
+## Observation
+<description of the behavior>
+
+## Reproduction Context
+- Discovered: <date>
+- Context: <what the user was trying to do>
+- Version: <Claude Code version if known>
+
+## Related
+- Feature area: <e.g., tools, subagents, skills>
+
+Labels: observation
+```
+
+### gh CLI Fallback
+
+If `gh` is unavailable or authentication fails:
+
+```
+1. Format the issue content
+2. Display to user with instructions:
+   "I couldn't create the issue automatically. Here's the formatted content
+   you can paste into a new issue at:
+   https://github.com/ddehart/claude-code-plugins/issues/new"
+3. Still offer local caching option
+```
+
+### Release Notes Updates
+
+Updates to the capabilities index happen **only in this source repo**, not on user machines:
+
+```
+1. Maintainer runs /release-notes in this repo
+2. Skill identifies new releases since last update
+3. Skill checks if any undocumented features now have official docs
+4. Skill adds new undocumented features from release notes
+5. Skill migrates newly-documented features to appropriate thematic files
+6. Changes are committed and released via plugin update
+```
+
+Users receive updates by running `/plugin update meta-claude@ddehart-plugins`.
+
+## Local Data Persistence
+
+### Observation Cache
+
+Following the pattern from `claude-mem` and other plugins, store user observations in:
+
+```
+~/.claude/plugin-observations/meta-claude.json
+```
+
+Schema:
+```json
+{
+  "observations": [
+    {
+      "id": "obs-001",
+      "description": "AskUserQuestion tool cannot be delegated to subagents via Task tool",
+      "context": "Attempted to create an interactive skill that runs in forked context",
+      "discovered": "2025-01-09",
+      "feature_area": "tools",
+      "issue_url": "https://github.com/ddehart/claude-code-plugins/issues/42",
+      "status": "submitted"
+    }
+  ],
+  "last_updated": "2025-01-09"
+}
+```
+
+**Why this location:**
+- `~/.claude/` is the standard user-scoped Claude data directory
+- Survives plugin updates (not in plugin cache)
+- Follows `claude-mem` pattern of plugin-specific subdirectories
+- Simple JSON is sufficient for this use case (no SQLite needed)
+
+## Skill Definition
+
+### YAML Frontmatter
+
+```yaml
+---
+name: self-documentation
+description: >
+  Explain Claude Code features, capabilities, and tools. Use for questions like
+  "how do skills work?", "what can you do?", "what's the difference between X and Y?",
+  "should I use a skill or slash command?". Also handles recording observations
+  about undocumented behaviors. Invoke with /self-documentation or ask naturally.
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - WebFetch
+  - Bash
+  - Write
+---
+```
+
+### Description Rationale
+
+- Includes natural trigger phrases users would say
+- Mentions the skill name for explicit invocation awareness
+- Covers all three concerns: reference, decisions, observations
+
+## Decision Guide
+
+Keep as a separate file (`decision-guide.md`) for questions about choosing between features:
+
+- Skills vs Slash Commands
+- Skills vs Subagents
+- Skills vs MCP Servers
+- When to combine features
+
+**Response pattern:** Make opinionated recommendations based on user's context, not just present options as equal choices.
+
+## Error Handling
+
+| Scenario | Handling |
+|----------|----------|
+| Reference file not found | Fall back to topic-index, report which file is missing |
+| WebFetch fails | Use cached key concepts from reference file |
+| gh CLI unavailable | Provide formatted issue for manual creation |
+| Cross-theme question unclear | Load topic-index, ask user to clarify if needed |
+| Observation already exists | Check local cache, inform user, offer to update |
+
+## File Structure
+
+```
+plugins/meta-claude/
+├── .claude-plugin/plugin.json          # Bump version
+├── skills/
+│   ├── session-export/                 # Existing skill
+│   │   └── ...
+│   └── self-documentation/             # New skill
+│       ├── SKILL.md
+│       └── references/
+│           ├── topic-index.md
+│           ├── decision-guide.md
+│           ├── core-features.md
+│           ├── integrations.md
+│           ├── configuration.md
+│           ├── workflows.md
+│           ├── undocumented.md
+│           └── observations.md
+```
+
+## Implementation Checklist
+
+### Phase 1: Core Skill
+- [ ] Create `skills/self-documentation/SKILL.md` with workflow instructions
+- [ ] Create `references/topic-index.md` with keyword mapping
+- [ ] Create `references/decision-guide.md` (migrate from existing skill)
+
+### Phase 2: Thematic References
+- [ ] Create `references/core-features.md` (skills, agents, slash commands, hooks)
+- [ ] Create `references/integrations.md` (MCP, plugins, IDE)
+- [ ] Create `references/configuration.md` (settings, permissions, sandbox)
+- [ ] Create `references/workflows.md` (git, parallel execution)
+- [ ] Create `references/undocumented.md` (release notes features)
+
+### Phase 3: Observations System
+- [ ] Create `references/observations.md` (seed with known observations)
+- [ ] Implement observation recording workflow in SKILL.md
+- [ ] Implement GitHub issue creation via gh CLI
+- [ ] Implement local cache at `~/.claude/plugin-observations/meta-claude.json`
+
+### Phase 4: Metadata & Documentation
+- [ ] Bump version in `plugins/meta-claude/.claude-plugin/plugin.json`
+- [ ] Bump version in `.claude-plugin/marketplace.json`
+- [ ] Update `README.md` with new skill documentation
+
+## Open Questions
+
+1. **Observation deduplication** - How to detect if an observation already exists in the repo's observations.md vs just locally cached?
+2. **PR automation scope** - Should the skill create full PRs or just prepare the branch/changes?
+3. **Reference file size monitoring** - How to ensure thematic files stay under target line counts as content grows?
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Reference files grow too large | Monitor line counts, split further if needed |
+| Topic index becomes stale | Include index update as part of reference updates |
+| gh CLI auth issues | Graceful fallback with manual instructions |
+| Local cache conflicts | Use append-only pattern, include unique IDs |

--- a/plugins/meta-claude/.claude-plugin/plugin.json
+++ b/plugins/meta-claude/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "meta-claude",
-  "description": "Claude Code productivity skills: session export, transcript management, and self-reflection tools",
-  "version": "1.1.0",
+  "description": "Claude Code productivity skills: session export, self-documentation for explaining features and capabilities, and self-reflection tools",
+  "version": "1.2.0",
   "author": {
     "name": "Derek DeHart"
   },
-  "keywords": ["sessions", "export", "transcripts", "productivity", "meta"]
+  "keywords": ["sessions", "export", "transcripts", "productivity", "meta", "documentation", "capabilities", "self-documentation"]
 }

--- a/plugins/meta-claude/skills/self-documentation/SKILL.md
+++ b/plugins/meta-claude/skills/self-documentation/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: self-documentation
+description: Explain Claude Code features, capabilities, and tools. Use for questions like "how do skills work?", "what can you do?", "what's the difference between X and Y?", "should I use a skill or slash command?". Also handles recording observations about undocumented behaviors. Invoke with /self-documentation or ask naturally.
+allowed-tools: ["Read", "Glob", "Grep", "WebFetch", "Bash", "Write"]
+---
+
+# Self-Documentation Skill
+
+Enable Claude Code to explain its own features, guide capability decisions, and track undocumented observations discovered through usage.
+
+## When to Activate
+
+This skill activates for:
+- **Direct questions**: "How do skills work?", "What can you do?", "What are your capabilities?"
+- **Decision questions**: "Should I use a skill or slash command?", "Is this a good use case for X?"
+- **Comparison questions**: "What's the difference between X and Y?", "When should I use X vs Y?"
+- **Best practices**: "What's the right way to do X?", "How should I structure Y?"
+- **Observation recording**: User reports discovering undocumented behavior
+
+## Reference Files
+
+The skill uses thematic reference files for token-efficient progressive disclosure:
+
+| File | Content |
+|------|---------|
+| `topic-index.md` | Keyword-to-file mapping (load first) |
+| `decision-guide.md` | Feature comparisons and decision trees |
+| `core-features.md` | Skills, agents, MCP, plugins, hooks, slash commands |
+| `configuration.md` | Settings, permissions, CLAUDE.md, sandboxing |
+| `integrations.md` | VS Code, IDE extensions, plugin marketplace |
+| `workflows.md` | Keyboard shortcuts, checkpointing, git automation |
+| `undocumented.md` | Features from release notes without official docs |
+| `observations.md` | User-discovered behaviors |
+
+## Workflow: Answering Questions
+
+### Step 1: Load Topic Index
+
+Read `references/topic-index.md` to identify which reference file(s) contain relevant information.
+
+### Step 2: Identify Relevant Files
+
+Match the user's question keywords to the topic index. For cross-theme questions (e.g., "How do skills work with MCP servers?"), identify multiple relevant files.
+
+### Step 3: Load Reference Files
+
+Read the identified reference file(s). Only load what's needed - avoid loading all files.
+
+### Step 4: Fetch Official Docs (If Needed)
+
+If the reference file includes a documentation URL and more detail is needed:
+1. Use WebFetch to retrieve the official documentation
+2. Synthesize with reference file content
+
+### Step 5: Respond
+
+Provide a conversational response that:
+- Directly answers the user's question
+- Highlights key concepts
+- Makes opinionated recommendations for decision questions (don't present all options as equal)
+- Does NOT proactively suggest related topics
+
+### Step 6: Update Reference (If New Info Learned)
+
+If WebFetch revealed new information, update the reference file's "Key concepts" section with today's date.
+
+## Workflow: Decision Questions
+
+For questions about choosing between features ("Should I use X or Y?"):
+
+1. Load `references/decision-guide.md`
+2. Find the relevant comparison section
+3. **Make a specific recommendation** based on the user's context
+4. Explain **why** this choice is best
+5. Provide actionable next steps
+
+**Response pattern:**
+> "For your use case, I recommend **[specific choice]**. Here's why:
+>
+> [Reasoning based on user's context]
+>
+> Next step: [Concrete action to take]"
+
+## Workflow: Recording Observations
+
+When a user discovers undocumented behavior (e.g., "I found that AskUserQuestion can't be delegated to subagents"):
+
+### Step 1: Confirm Value
+
+Verify this is a new observation worth recording:
+- Is it about Claude Code behavior?
+- Is it not already documented?
+- Is it reproducible or specific enough to be useful?
+
+### Step 2: Check for Duplicates
+
+Before creating an issue, check if this observation already exists:
+
+1. **Check local cache**: Read `~/.claude/plugin-observations/meta-claude.json` if it exists
+2. **Check repo observations**: Read `references/observations.md` in this skill
+
+**If a similar observation exists:**
+- Inform the user: "This observation appears similar to an existing one: [description]"
+- Ask if they want to:
+  - Update the existing observation with new context
+  - Create a new issue anyway (if sufficiently different)
+  - Skip recording
+
+**If no duplicate found:** Proceed to Step 3.
+
+### Step 3: Propose Issue Creation
+
+Ask the user:
+> "This seems like a valuable observation. Would you like me to create a GitHub issue in the plugin repo to track it?"
+
+Wait for user confirmation.
+
+### Step 4: Create GitHub Issue
+
+Use `gh` CLI to create an issue in `ddehart/claude-code-plugins`:
+
+```bash
+gh issue create --repo ddehart/claude-code-plugins \
+  --title "[Observation] <brief description>" \
+  --body "<formatted body>" \
+  --label "observation"
+```
+
+**Issue format:**
+```markdown
+## Observation
+<description of the behavior>
+
+## Reproduction Context
+- Discovered: <date>
+- Context: <what the user was trying to do>
+- Version: <Claude Code version if known>
+
+## Related
+- Feature area: <e.g., tools, subagents, skills>
+```
+
+### Step 5: Handle gh CLI Failure
+
+If `gh` is unavailable or authentication fails:
+
+1. Format the issue content
+2. Display to user:
+   > "I couldn't create the issue automatically. Here's the formatted content you can paste into a new issue at: https://github.com/ddehart/claude-code-plugins/issues/new"
+3. Continue to Step 6
+
+### Step 6: Offer Additional Actions
+
+Ask the user:
+> "Would you also like me to:
+> - Cache this observation locally (at ~/.claude/plugin-observations/meta-claude.json)?
+> - Create a PR to add it to the skill's observations.md?"
+
+Based on user choice:
+- **Cache locally**: Write to `~/.claude/plugin-observations/meta-claude.json`
+- **Create PR**: Branch from main, update `observations.md`, create PR via `gh pr create`
+- **Neither**: Done
+
+### Local Cache Schema
+
+```json
+{
+  "observations": [
+    {
+      "id": "obs-001",
+      "description": "...",
+      "context": "...",
+      "discovered": "YYYY-MM-DD",
+      "feature_area": "...",
+      "issue_url": "https://github.com/...",
+      "status": "submitted"
+    }
+  ],
+  "last_updated": "YYYY-MM-DD"
+}
+```
+
+## Workflow: Release Notes Updates
+
+**Important:** Index updates happen only in the source repo, not on user machines.
+
+When maintaining the reference files (as repo maintainer):
+
+1. Run `/release-notes` to get latest Claude Code releases
+2. Identify releases newer than the "Latest Release" in `undocumented.md`
+3. For each new feature:
+   - Check if official docs exist (fetch docs map)
+   - If documented: Add to appropriate thematic file
+   - If undocumented: Add to `undocumented.md`
+4. Check if any previously undocumented features now have docs (migrate them)
+5. Update "Latest Release" header
+6. Commit and release via plugin update
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Reference file not found | Fall back to topic-index, report which file is missing |
+| WebFetch fails | Use cached key concepts from reference file |
+| gh CLI unavailable | Provide formatted issue for manual creation |
+| Cross-theme question unclear | Load topic-index, ask user to clarify if needed |
+| Observation already exists | Check local cache, inform user, offer to update |
+
+## Plugin Repo
+
+Issues and PRs go to: `ddehart/claude-code-plugins`
+
+This skill is part of the `meta-claude` plugin in that marketplace.

--- a/plugins/meta-claude/skills/self-documentation/references/configuration.md
+++ b/plugins/meta-claude/skills/self-documentation/references/configuration.md
@@ -1,0 +1,160 @@
+# Configuration
+
+Settings, permissions, memory, and customization options for Claude Code.
+
+**Last updated**: 2025-01-09
+
+---
+
+## Memory Management (CLAUDE.md)
+
+**What it is**: System for retaining preferences, coding style, project conventions across sessions via memory files
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/memory
+
+**Key concepts**:
+- **Memory hierarchy** (precedence order): Enterprise Policy (org-wide), Project Memory (`./CLAUDE.md` or `./.claude/CLAUDE.md`), User Memory (`~/.claude/CLAUDE.md`), Project Local (deprecated)
+- **Auto-loading**: Files loaded automatically on launch; recurses up from cwd to (but not including) root directory
+- **File imports**: `@path/to/file` syntax includes external docs; recursive up to 5 hops deep
+- **Quick addition**: Start input with `#` to rapidly add memories (prompts for location)
+- **Management**: `/memory` (edit in editor), `/init` (bootstrap CLAUDE.md for codebase)
+- **Best practices**: Be specific ("2-space indentation"), organize with markdown headings, review periodically as projects evolve
+
+---
+
+## Modular Rules (.claude/rules/)
+
+**What it is**: Organized, topic-specific instruction files that extend project memory with focused guidelines for code style, testing, security, and other conventions
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/memory
+
+**Key concepts**:
+- **Directory structure**: Place `.md` files in `.claude/rules/` for automatic loading alongside `CLAUDE.md`
+- **Path-specific rules**: Use YAML frontmatter with `paths` field for conditional rules (e.g., `paths: src/api/**/*.ts`)
+- **Glob patterns**: Standard glob syntax including `**/*.ts`, `*.md`, braces `{ts,tsx}`, and multiple patterns
+- **Subdirectories**: Organize rules hierarchically (e.g., `frontend/`, `backend/`) - all `.md` files discovered recursively
+- **User-level rules**: Personal rules at `~/.claude/rules/` apply to all projects (lower priority than project rules)
+- **Symlinks supported**: Share common rules across projects via symlinks (circular symlinks handled gracefully)
+- **Best practices**: Keep rules focused (one topic per file), use descriptive filenames, use conditional paths sparingly, organize with subdirectories
+
+---
+
+## Model Configuration
+
+**What it is**: Model selection, aliasing, and behavior customization for different tasks and account types
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/model-config
+
+**Key concepts**:
+- **Primary aliases**: `sonnet` (4.5, daily coding), `opus` (4.5, complex reasoning), `haiku` (4.5, fast tasks), `default` (recommended for account type)
+- **Special aliases**: `opusplan` (opus for plan mode, sonnet for execution), `sonnet[1m]` (million-token extended context)
+- **Configuration methods** (priority order): `/model <alias>` (mid-session), `claude --model <alias>` (startup), `ANTHROPIC_MODEL` (environment), settings.json (persistent)
+- **Environment variables**: ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL, CLAUDE_CODE_SUBAGENT_MODEL
+- **Prompt caching**: DISABLE_PROMPT_CACHING variables (global overrides model-specific)
+- **Haiku 4.5**: Auto-uses Sonnet in plan mode (SonnetPlan behavior by default) for Pro users
+
+---
+
+## Permission Management
+
+**What it is**: Tool usage control through allow/ask/deny rules for security and workflow customization
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/settings
+
+**Key concepts**:
+- **Three modes**: Allow (auto-approve), Ask (confirmation prompt), Deny (block tool use)
+- **Configuration**: settings.json at user (`~/.claude/`), project (`.claude/`, shared), or local (`.claude/settings.local.json`, personal)
+- **`/permissions` command**: Manage tool permissions interactively (v1.0.7+)
+- **Rule format**: Array of permission rules per mode (e.g., `Bash(git push:*)`, `Read(./.env)`)
+- **Use cases**: Prevent dangerous operations, require confirmation for sensitive actions, enable autonomous work within boundaries
+- **MCP integration**: Works with MCP tools using pattern `mcp__<server>__<tool>`
+- **Wildcard MCP permissions** (v2.0.70): Use `mcp__server__*` syntax to allow/deny all tools from a server
+
+---
+
+## Sandboxing
+
+**What it is**: Isolated execution environments using OS-level security primitives to restrict filesystem and network access
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/sandboxing
+
+**Key concepts**:
+- **Activation**: `/sandbox` command enables sandboxed bash with default settings
+- **Filesystem isolation**: Read/write limited to current working directory; read-only system access excluding denied directories; modifications outside cwd require permission
+- **Network isolation**: Access restricted to approved domains via proxy; new domain requests trigger confirmation; restrictions apply to all subprocesses
+- **OS-level enforcement**: Linux uses bubblewrap, macOS uses Seatbelt sandbox
+- **Security benefits**: Protection against prompt injection, data exfiltration, malicious downloads, unauthorized API calls
+- **Policy control**: `allowUnsandboxedCommands` setting disables dangerouslyDisableSandbox escape hatch at policy level for enterprise environments
+- **Limitations**: Minimal performance impact; Linux and macOS only; some tools (watchman, docker) require special configuration
+- **Autonomous work**: Reduces permission prompts within defined boundaries
+
+---
+
+## Output Styles
+
+**What it is**: Modifications to Claude Code's system prompt that adapt it for different use cases beyond software engineering (educational, collaborative modes)
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/output-styles
+
+**Key concepts**:
+- **Built-in styles**: Default (efficient software engineering), Explanatory (educational insights between tasks), Learning (collaborative with TODO(human) labels)
+- **How they work**: Directly modify system prompt; exclude code-gen instructions for non-default styles, add custom guidance
+- **vs other customizations**: Output styles replace default prompt entirely (vs CLAUDE.md supplements it), affect main loop only (vs Agents handle specific tasks), "stored system prompts" (vs slash commands are "stored prompts")
+- **Configuration**: `/output-style` (menu), `/output-style [name]` (direct switch), `/config` menu; stored in `.claude/settings.local.json` (project level)
+- **Custom styles**: Create via `/output-style:new I want...`; saved as markdown with frontmatter at `~/.claude/output-styles` (user) or `.claude/output-styles` (project)
+- **Frontmatter options**: `keep-coding-instructions: true` to retain default code generation guidance when using custom styles
+
+---
+
+## Status Line Customization
+
+**What it is**: Customizable bottom-of-screen display similar to shell prompts (Oh-my-zsh style), updating with conversation changes
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/statusline
+
+**Key concepts**:
+- **Setup**: `/statusline` (interactive), manual configuration via `statusLine` command in settings.json
+- **Display**: First line of stdout becomes status line text; supports ANSI color codes; updates max every 300ms
+- **Available variables**: Model (id, display_name), Workspace (current_dir, project_dir), Cost metrics (total_cost_usd, duration, lines added/removed), Session (session_id, cwd, version, output_style)
+- **Configuration format**: JSON with type ("command"), command path, and padding
+- **Implementation tips**: Keep concise (one line), use emojis/colors for scannability, use `jq` for JSON parsing, ensure executable permissions
+
+---
+
+## Cost Tracking & Usage Management
+
+**What it is**: Token consumption monitoring, usage limits, and cost optimization for Claude Code sessions
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/costs
+
+**Key concepts**:
+- **Average costs**: $6/developer/day typical; below $12/day for 90% of users
+- **`/cost` command**: Session-level token statistics (total cost, API duration, wall-clock time, code changes); not intended for Claude Max/Pro subscribers
+- **`/usage` command**: Plan usage limits and rate limit status for subscription plans
+- **Budget controls**: `--max-budget-usd` flag sets spending limit per session (SDK/headless mode)
+- **Rate limit recommendations**: 200k-300k TPM for small teams (1-5 users), scaling down to 10k-15k TPM for 500+ user organizations
+- **Plan management**: Workspace spend limits via Claude Console (Admin role required); historical usage reporting; automatic "Claude Code" workspace creation
+- **Cost optimization**: Auto-compaction at 95% capacity, specific queries, task breakdown, clearing history between sessions
+
+---
+
+## Attribution Setting
+
+**What it is**: Configuration to customize commit and PR bylines for Claude-generated content
+
+**Introduced**: v2.0.62 (2025-12)
+
+**What we know**:
+- New `attribution` setting replaces deprecated `includeCoAuthoredBy`
+- More flexible control over how Claude's contributions are credited
+- Allows customizing or disabling the Co-Authored-By line
+
+**Configuration**:
+```json
+{
+  "attribution": {
+    "enabled": true,
+    "format": "co-author"
+  }
+}
+```

--- a/plugins/meta-claude/skills/self-documentation/references/core-features.md
+++ b/plugins/meta-claude/skills/self-documentation/references/core-features.md
@@ -1,0 +1,144 @@
+# Core Features
+
+Foundational Claude Code capabilities that enable extensibility and customization.
+
+**Last updated**: 2025-01-09
+
+---
+
+## Claude Code Overview
+
+**What it is**: High-level overview of Claude Code's core capabilities, characteristics, and setup requirements
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/overview
+
+**Key concepts**:
+- **Core capabilities**: Build features (natural language → code), debug & fix issues, codebase navigation, automation (lint fixes, merge conflicts, release notes)
+- **Terminal-native**: Integrates into existing developer workflows, not a separate IDE
+- **Direct action**: Can edit files, execute commands, create commits directly
+- **MCP integration**: Access external resources (Google Drive, Figma, Slack) through Model Context Protocol
+- **Unix philosophy**: Composable, scriptable, pipeable for CI/CD integration
+- **Enterprise ready**: Available via Claude API, AWS Bedrock, Google Vertex AI with security/privacy/compliance
+- **VS Code extension (Beta)**: Graphical IDE alternative without terminal requirements
+- **Setup**: Requires Node.js 18+, install via `npm install -g @anthropic-ai/claude-code`
+
+---
+
+## Skills System
+
+**What it is**: Modular capabilities that extend Claude's functionality with specialized knowledge and workflows. Skills consist of a SKILL.md file with YAML frontmatter (name, description) plus optional supporting files (scripts, references, assets).
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/skills
+
+**Key concepts**:
+- **Model-invoked** (not user-invoked) - Claude autonomously decides when to use based on context and description field
+- **Auto-discovery** - Skills activate automatically when relevant to request, unlike slash commands which require explicit invocation
+- **Progressive disclosure** - Three-level loading: metadata (always in context ~100 words), SKILL.md body (when triggered <5k words), bundled resources (as needed)
+- **Multi-file structure** - SKILL.md + optional supporting files (references/, scripts/, templates/); manages context efficiently by deferring non-essential information
+- **Three scopes**: Personal (`~/.claude/skills/`), Project (`.claude/skills/`, git-shared), Plugin (bundled with Claude Code plugins)
+- **Tool restrictions** - `allowed-tools` frontmatter field limits available tools within skill for security/safety
+- **Description field is critical** - Must be specific with trigger terms for discoverability (max 1024 characters); tells Claude when to activate
+- **Supporting files**: `scripts/` (executable code, may run without loading to context), `references/` (docs loaded into context as needed), `assets/` (files used in output, not loaded to context)
+- **Best practices**: One capability per skill, write specific descriptions with user trigger terms, test activation timing with team, document versions
+- **Sharing**: Via plugins (recommended, marketplace distribution) or project repository (`.claude/skills/`, team auto-gets on pull)
+- **vs Slash Commands**: Skills are "complex workflows Claude discovers automatically" with multi-file support; slash commands are "simple, reusable prompts" requiring explicit invocation
+- **Subagent integration** (v2.0.43+): Subagents can auto-load specific skills via `skills` frontmatter field; skills become available only within subagent's context for specialized expertise
+
+---
+
+## MCP (Model Context Protocol) Servers
+
+**What it is**: Open-source standard for AI-tool integrations enabling Claude Code to access external tools, databases, and APIs (hundreds of third-party services)
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/mcp
+
+**Key concepts**:
+- **Core capabilities**: Retrieve features from issue trackers, analyze monitoring data, query databases, access design files, automate workflows
+- **Three transport types**: HTTP (recommended for cloud services), SSE (deprecated but functional), Stdio (local processes for custom scripts)
+- **Three scopes**: Local (default, personal project configs), Project (team-shared via `.mcp.json` in version control), User (cross-project personal utilities)
+- **Scope precedence**: Local overrides project and user when naming conflicts occur
+- **Popular integrations**: Sentry, Hugging Face, Jam, Asana, Jira, Linear, Notion, Airtable, HubSpot, PostgreSQL, Stripe, Square, PayPal
+- **Management commands**: `claude mcp list/get/remove`, `/mcp` within Claude Code
+- **Authentication**: OAuth 2.0 automatic for HTTP servers, tokens stored securely and auto-refreshed
+- **Enterprise**: System-wide `managed-mcp.json` for standardization, allowlists/denylists for control
+- **Tool naming**: MCP tools use pattern `mcp__<server-name>__<tool-name>`
+
+---
+
+## Plugins
+
+**What it is**: Extensions that add custom functionality (commands, agents, skills, hooks, MCP servers) that can be shared across projects and teams
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/plugins
+
+**Key concepts**:
+- **Components**: Commands (slash commands), Agents (specialized AI assistants), Skills (model-invoked capabilities), Hooks (event handlers), MCP Servers (external integrations)
+- **Structure**: `.claude-plugin/plugin.json` (metadata), `commands/`, `agents/`, `skills/`, `hooks/` directories
+- **Installation**: `/plugin` interactive menu (browse/discover), direct commands (`install/enable/disable`)
+- **Marketplaces**: Catalogs of plugins, add via `/plugin marketplace add your-org/claude-plugins`
+- **Team configuration**: Automatic installation via `.claude/settings.json` in repository
+- **Development**: Create plugin.json, add components, test locally, distribute through catalogs
+- **Best practices**: Semantic versioning, comprehensive README, local testing, organize by functionality
+- **User roles**: Plugin users (discover/install), Developers (create/distribute), Team leaders (governance/catalogs)
+
+---
+
+## Agents and Subagents
+
+**What it is**: Specialized AI assistants that Claude Code can delegate tasks to. Each operates with its own separate context window and can be configured with specific system prompts, tools, and models for task-specific problem-solving.
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/sub-agents
+
+**Key concepts**:
+- **Benefits**: Context preservation (separate windows prevent main conversation pollution), specialized expertise (fine-tuned instructions), reusability (work across projects), flexible permissions (different tool access levels)
+- **Creation**: `/agents` → Create New Agent → Choose scope → Define/customize → Select tools → Save; or manually create Markdown files with YAML frontmatter
+- **File structure**: YAML frontmatter with `name` (required, lowercase-hyphenated), `description` (required, natural language purpose), `tools` (optional, comma-separated), `model` (optional, sonnet/opus/haiku/inherit), `disallowedTools` (optional, explicit tool blocking)
+- **File locations** (priority order): Project (`.claude/agents/`, highest), CLI flag (`--agents`, add subagents dynamically), User (`~/.claude/agents/`, lower), Plugin (`agents/` directory)
+- **Usage**: Automatic delegation (Claude proactively identifies based on descriptions; use "PROACTIVELY" or "MUST BE USED" in description), Explicit invocation (direct requests to use specific subagent), @-mention support with typeahead
+- **Tool access**: Inherits all tools if not specified; can restrict to specific tools via `tools` field; can explicitly block tools via `disallowedTools` field; includes MCP server tools
+- **Skill auto-loading** (v2.0.43+): `skills` frontmatter field loads specific skills when subagent activates; enables specialized knowledge per subagent; skills unload when subagent completes
+- **Built-in subagents**: Plan subagent (automatic codebase research during plan mode using Read/Glob/Grep/Bash tools with Sonnet model, prevents infinite nesting)
+- **Best practices**: Start with Claude-generated then customize, design focused subagents with single responsibilities, write detailed prompts with constraints, limit tool access to necessary only, version control project subagents
+- **Advanced**: Chaining (multiple sequential subagents), dynamic selection (Claude intelligently chooses), model selection ('inherit' for consistency), subagent resumption (Claude can resume previous subagents), dynamic model choice (Claude selects model for subagent tasks)
+
+---
+
+## Slash Commands
+
+**What it is**: Tools that control Claude's behavior via frequently-used prompts, invoked by user explicitly or by Claude programmatically. Can be built-in or custom Markdown files.
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/slash-commands
+
+**Key concepts**:
+- **Invocation patterns**: Direct (`/command`), plugin-prefixed (`/plugin:command` for disambiguation), with arguments (`/command arg1 arg2`)
+- **Built-in commands**: `/help` (usage), `/clear` (history), `/model` (selection), `/cost` (tokens), `/memory` (CLAUDE.md editing), `/sandbox` (sandboxed bash), `/mcp` (server management), `/todos` (view current todo list)
+- **Custom commands**: Single Markdown files in `.claude/commands/` (project, git-shared) or `~/.claude/commands/` (personal, cross-project)
+- **Structure**: Single file with frontmatter, simpler than Skills' multi-file structure
+- **Features**: Namespacing via subdirectories, arguments (`$ARGUMENTS` for all, `$1`/`$2` for specific), bash execution (prefix `!`), file references (`@` notation), frontmatter metadata
+- **Frontmatter options**: Description, allowed-tools, model selection, disable-model-invocation
+- **Execution**: SlashCommand tool allows Claude to invoke programmatically; disable via `/permissions` or `disable-model-invocation: true`
+- **MCP commands**: Format `mcp__<server-name>__<prompt-name>` from MCP server prompts
+- **Plugin commands**: Auto-discovered when plugins installed
+- **vs Skills**: Commands are "simple, reusable prompts" requiring explicit invocation; Skills are "complex workflows Claude discovers automatically" with multi-file support
+
+---
+
+## Hooks
+
+**What it is**: Automated bash scripts that execute in response to specific events during Claude Code sessions, enabling custom automation, validation, and integration workflows
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/hooks
+
+**Key concepts**:
+- **Execution model**: All matching hooks run in parallel with 60-second default timeout; receive JSON via stdin, return structured output to control Claude
+- **Configuration locations**: `~/.claude/settings.json` (user), `.claude/settings.json` (project), `.claude/settings.local.json` (local project), enterprise managed policy
+- **10 event types**: PreToolUse (before tool execution, can modify tool inputs), PostToolUse (after completion), UserPromptSubmit (prompt submission), Notification (permission requests with matcher values for event filtering), PermissionRequest (automatically approve/deny tool permissions), Stop (main agent finish, prompt-based matching), SubagentStop (subagent finish), SessionStart (session begins), SessionEnd (session terminates), PreCompact (before context compacting)
+- **Matcher patterns**: Exact (`Write`), regex (`Edit|Write`), wildcard (`*`), prompt-based (Stop hooks can match against user prompts), Notification and PermissionRequest matcher values for event-specific filtering; case-sensitive
+- **Exit codes**: 0 (success, stdout to transcript), 2 (blocking error, stderr to Claude), other (non-blocking error, stderr to user)
+- **JSON output**: Advanced control with `continue`, `decision`, `reason`, and hook-specific parameters
+- **Hook input fields**: `tool_use_id` field in PreToolUse and PostToolUse hooks enables correlation between pre/post events for same tool call
+- **PermissionRequest hook**: Runs when user shown permission dialog; use decision control to allow/deny automatically; recognizes same matcher values as PreToolUse
+- **Environment variables**: `CLAUDE_PROJECT_DIR` (project root path), `CLAUDE_ENV_FILE` (SessionStart persistence), `CLAUDE_CODE_REMOTE` (remote/local indicator)
+- **Security warning**: Execute arbitrary shell commands automatically—validate/sanitize input, quote variables, use absolute paths, avoid sensitive files, test in safe environments
+- **MCP integration**: Works with MCP tools using pattern `mcp__<server>__<tool>`
+- **Debugging**: Use `claude --debug` for execution details, matched commands, exit codes, output

--- a/plugins/meta-claude/skills/self-documentation/references/decision-guide.md
+++ b/plugins/meta-claude/skills/self-documentation/references/decision-guide.md
@@ -1,0 +1,239 @@
+# Decision Guide
+
+This guide helps you decide when to use Skills vs other Claude Code features. Based on the [Skills Explained blog post](https://www.claude.com/blog/skills-explained) and official documentation.
+
+## Mental Model
+
+**Skills are specialized training materials** that Claude dynamically discovers and loads when relevant. They teach Claude portable expertise without requiring re-explanation in each conversation.
+
+Think of Skills as:
+- Reference manuals Claude consults when needed
+- Domain expertise that persists across conversations
+- Self-contained packages of knowledge + tools
+
+## When to Create a Skill
+
+### The Core Heuristic
+
+> **"If you find yourself typing the same prompt repeatedly across multiple conversations, it's time to create a Skill."**
+
+### Good Skill Use Cases
+
+**Organizational Procedures:**
+- Brand guidelines and design systems
+- Compliance requirements
+- Document templates and formatting standards
+- Code review checklists
+- Release procedures
+
+**Domain-Specific Expertise:**
+- Excel formula reference and best practices
+- PDF manipulation workflows
+- Data analysis methodologies
+- API integration patterns
+- Testing strategies
+
+**Personal Preferences:**
+- Note-taking systems
+- Coding conventions and patterns
+- Commit message formats
+- Documentation styles
+- Project structure preferences
+
+### When NOT to Use Skills
+
+**One-off tasks:** If you'll only need the instruction once, use a regular prompt instead.
+
+**Explicit user control needed:** Use slash commands for operations that require deliberate user invocation.
+
+**Independent task execution:** Use subagents when you need context isolation and specific tool restrictions.
+
+**Data access:** Use MCP servers to connect to external data sources (combine with Skills to teach what to do with the data).
+
+## Skills vs Other Features
+
+### Skills vs Slash Commands
+
+| Aspect | Skills | Slash Commands |
+|--------|--------|----------------|
+| **Invocation** | Claude discovers automatically | User types `/command` |
+| **Purpose** | Teach expertise, complex workflows | Quick, reusable prompts |
+| **Structure** | Multi-file (SKILL.md + resources) | Single Markdown file |
+| **Best for** | Team workflows, shared expertise | Explicit user-directed operations |
+| **Example** | Automated code review standards | `/review` to trigger review |
+
+**Decision question:** Does Claude need to recognize when to use this automatically?
+- **Yes** → Skill
+- **No** → Slash Command
+
+### Skills vs Subagents
+
+| Aspect | Skills | Subagents |
+|--------|--------|-----------|
+| **Purpose** | Teach portable expertise | Execute independent tasks |
+| **Context** | Shares main conversation context | Separate context window |
+| **Tools** | Can restrict via `allowed-tools` | Configurable tool access |
+| **Best for** | Knowledge that applies everywhere | Specialized, isolated work |
+| **Example** | Brand guidelines skill | code-reviewer subagent |
+
+**Decision question:** Does this need its own isolated context and tool restrictions?
+- **Yes** → Subagent
+- **No** → Skill
+
+### Skills vs MCP Servers
+
+| Aspect | Skills | MCP Servers |
+|--------|--------|-------------|
+| **Purpose** | Teach what to do with data | Connect to data sources |
+| **Function** | Instructions and workflows | Tools for data access |
+| **Best for** | Domain expertise | External integrations |
+| **Example** | "How to analyze Linear issues" | Linear MCP server (data access) |
+
+**Recommended:** Use both together! MCP provides the data, Skills teach how to use it.
+
+**Decision question:** Do you need to access external data or teach Claude what to do with it?
+- **Access data** → MCP Server
+- **Teach usage** → Skill
+- **Both** → Use together
+
+### Skills + Subagents (Integration Pattern)
+
+| Aspect | Skills Alone | Skills + Subagents |
+|--------|--------------|-------------------|
+| **Purpose** | Teach expertise in main conversation | Provide expertise to specific subagent tasks |
+| **Loading** | Auto-discovered by description | Auto-loaded when subagent activates |
+| **Context** | Main conversation context | Subagent's separate context |
+| **Best for** | General-purpose knowledge | Task-specific specialized expertise |
+| **Example** | Code review standards (always available) | npm-update-advisor (only for package-updater) |
+
+**Integration Pattern** (v2.0.43+):
+Subagents can auto-load skills using the `skills` frontmatter field, combining knowledge (skill) with execution (subagent).
+
+**When to use this pattern:**
+- Knowledge useful in BOTH main conversation AND automation
+- Subagent needs specialized domain expertise
+- Want to avoid duplicating logic between main and subagent contexts
+- Context efficiency matters (skill loads only when needed)
+
+**Example: npm-update-advisor + package-updater**
+```yaml
+# Skill: Contains npm diagnostic logic
+name: npm-update-advisor
+description: Analyzes npm update strategies based on semver, lock files...
+
+# Subagent: Orchestrates package updates, loads skill
+name: package-updater
+skills: npm-update-advisor
+tools: Bash, Read
+```
+
+**Result:**
+- User asks npm questions → Skill triggers in main conversation
+- Security automation runs → Subagent loads skill for smart decisions
+- Single source of truth, dual contexts
+
+### Skills vs Prompts
+
+| Aspect | Skills | Prompts |
+|--------|--------|---------|
+| **Persistence** | Across all conversations | Current conversation only |
+| **Discovery** | Automatic when relevant | Manual entry each time |
+| **Structure** | Organized files + resources | Plain text |
+| **Best for** | Recurring needs | One-off instructions |
+
+**Decision question:** Will you need this in future conversations?
+- **Yes** → Skill
+- **No** → Prompt
+
+## Practical Examples
+
+### Example 1: Repetitive Code Reviews
+
+**Scenario:** You want Claude to always check for security issues, test coverage, and accessibility in PRs.
+
+**Solution:** Create a `code-review-standards` skill
+- **Why skill?** Applies to every code review across multiple conversations
+- **Why not slash command?** You want Claude to recognize review context automatically
+- **Why not subagent?** Doesn't need isolated context; guidance applies to main conversation
+
+### Example 2: Linear Workflow Automation
+
+**Scenario:** You want Claude to fetch Linear issues and analyze them for patterns.
+
+**Solution:** MCP Linear server + `linear-analysis` skill
+- **MCP for:** Fetching issue data (mcp__linear__list_issues)
+- **Skill for:** Teaching analysis patterns, reporting format, insights to look for
+- **Together:** MCP provides data, skill teaches what to do with it
+
+### Example 3: Quick PR Template
+
+**Scenario:** You want to generate PR descriptions in a specific format.
+
+**Solution:** Create `/pr-template` slash command
+- **Why slash command?** Explicit user action, not automatic discovery
+- **Why not skill?** User deliberately triggers it when creating PRs
+- **Why not subagent?** Doesn't need isolated context
+
+### Example 4: Security Vulnerability Analysis
+
+**Scenario:** You want dedicated analysis of security issues with limited tool access.
+
+**Solution:** Create `security-analyzer` subagent
+- **Why subagent?** Needs isolated context to focus only on security concerns
+- **Tool restrictions:** Only Read, Grep, WebFetch for CVE lookup
+- **Why not skill?** Needs separate context window and strict tool boundaries
+
+## Quick Decision Tree
+
+```
+Need expertise across multiple conversations?
+├─ No → Use regular prompt
+└─ Yes → Continue...
+
+    Does Claude need to discover this automatically?
+    ├─ No → Use slash command
+    └─ Yes → Continue...
+
+        Need isolated context or tool restrictions?
+        ├─ Yes → Use subagent
+        └─ No → Continue...
+
+            Need to access external data?
+            ├─ Yes → Use MCP server (+ skill for usage patterns)
+            └─ No → Use skill
+```
+
+## Summary Heuristics
+
+**Create a Skill when:**
+- You're repeating the same instruction across conversations
+- You want Claude to automatically recognize when to apply knowledge
+- You need to package expertise with reference files
+- You want team members to automatically get standardized guidance
+
+**Use Slash Command when:**
+- You want explicit user control over invocation
+- The operation is simple and doesn't need auto-discovery
+- You prefer typing `/command` rather than having Claude guess
+
+**Use Subagent when:**
+- You need isolated context for focused work
+- You want to restrict which tools are available
+- You're delegating independent task execution
+- You want to preserve main conversation context
+
+**Use MCP Server when:**
+- You need to access external data or services
+- You want to integrate third-party tools
+- Combine with Skills to teach Claude how to use the data
+
+---
+
+**Last updated:** 2025-01-09
+
+**Sources:**
+- [Skills Explained Blog Post](https://www.claude.com/blog/skills-explained)
+- [Skills Documentation](https://docs.anthropic.com/en/docs/claude-code/skills)
+- [Sub-agents Documentation](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
+- [Slash Commands Documentation](https://docs.anthropic.com/en/docs/claude-code/slash-commands)
+- [MCP Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp)

--- a/plugins/meta-claude/skills/self-documentation/references/integrations.md
+++ b/plugins/meta-claude/skills/self-documentation/references/integrations.md
@@ -1,0 +1,86 @@
+# Integrations
+
+IDE extensions, platform integrations, and deployment options for Claude Code.
+
+**Last updated**: 2025-01-09
+
+---
+
+## VS Code Extension
+
+**What it is**: Beta native IDE integration providing graphical sidebar interface as alternative to terminal usage
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/vs-code
+
+**Key concepts**:
+- **Native IDE experience**: Dedicated Claude Code sidebar panel accessed via Spark icon
+- **Core features**: Plan review mode, auto-accept edits mode, @-mention file management, MCP server support, conversation history, multiple simultaneous sessions, keyboard shortcuts, slash commands
+- **Requirements**: VS Code 1.98.0+; install from Visual Studio Code Extension Marketplace
+- **Third-party providers**: Configure environment variables in VS Code settings for Bedrock/Vertex AI
+- **Unavailable features**: MCP server configuration (must use CLI), subagents setup, checkpoints, advanced shortcuts (#, !, tab completion)
+- **Security considerations**: Auto-edit permissions may modify IDE configs with auto-execution risks; use Restricted Mode and manual approval for untrusted workspaces
+- **Legacy CLI integration**: Terminal-based integration offers selection context sharing, IDE diff viewing, automatic diagnostic sharing
+
+---
+
+## Azure AI Foundry
+
+**What it is**: Third-party model provider integration enabling Claude Code access through Microsoft's Azure AI Foundry platform
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/azure-ai-foundry
+
+**Key concepts**:
+- **Prerequisites**: Azure subscription with Azure AI Foundry access, RBAC permissions, optional Azure CLI for credential management
+- **Resource provisioning**: Create Claude resource in Azure AI Foundry, deploy three model variants (Opus, Sonnet, Haiku)
+- **Authentication options**: API key method (`ANTHROPIC_FOUNDRY_API_KEY`) or Microsoft Entra ID (automatic via Azure SDK default credential chain)
+- **Essential environment variables**: `CLAUDE_CODE_USE_FOUNDRY=1` (activation), `ANTHROPIC_FOUNDRY_RESOURCE={resource}` (resource name), model-specific deployment mappings
+- **Permissions**: "Azure AI User" and "Cognitive Services User" roles sufficient, custom roles require `Microsoft.CognitiveServices/accounts/providers/*` dataAction
+- **Limitations**: `/login` and `/logout` commands unavailable when using AI Foundry
+- **Common issues**: Authentication errors typically from unconfigured Entra ID (configure or set API key)
+
+---
+
+## Claude Code for Desktop
+
+**What it is**: Native desktop application providing graphical interface without terminal requirement
+
+**Introduced**: v2.0.51 (2025-11)
+
+**What we know**:
+- Available at https://claude.com/download
+- Third deployment option alongside CLI and VS Code extension
+- Native desktop experience without terminal familiarity required
+
+**Deployment options**:
+- **CLI**: Terminal-native, scriptable, keyboard-driven
+- **VS Code Extension**: IDE sidebar integration
+- **Desktop App**: Standalone native application
+
+**Unanswered questions**:
+- Full feature parity with CLI
+- Supported operating systems
+- MCP server and custom agent support
+
+---
+
+## Claude in Chrome (Beta)
+
+**What it is**: Chrome extension for browser control directly from Claude Code
+
+**Introduced**: v2.0.72 (2025-12)
+
+**What we know**:
+- Chrome extension at https://claude.ai/chrome
+- Enables browser automation: navigate, read content, interact with elements, take screenshots
+- More powerful than WebFetch - active browser control vs. passive fetching
+
+**Use cases**:
+- Web application testing
+- Form automation
+- Content extraction
+- UI verification
+
+**Unanswered questions**:
+- Full list of available browser actions
+- Security model and authentication handling
+- Cross-browser support

--- a/plugins/meta-claude/skills/self-documentation/references/observations.md
+++ b/plugins/meta-claude/skills/self-documentation/references/observations.md
@@ -1,0 +1,36 @@
+# Observations
+
+User-discovered behaviors and findings not documented in official Claude Code documentation. These observations come from hands-on testing and community contributions.
+
+**How to contribute**: When you discover undocumented behavior, use this skill to record it. The skill will create a GitHub issue and optionally cache locally.
+
+---
+
+## AskUserQuestion Cannot Be Delegated to Subagents
+
+**Observation**: The AskUserQuestion tool cannot be used when running in a forked/subagent context via the Task tool.
+
+**Discovered**: 2025-01-09
+
+**Context**: Attempted to create an interactive skill that runs in forked context (`context: fork`) to ask users questions during execution.
+
+**Behavior**: When a subagent attempts to use AskUserQuestion, the tool is not available or fails. Interactive questioning only works in the main conversation context.
+
+**Implication**: Skills that need to ask users questions must run in the main context, not as forked subagents. Use `context: fork` only for non-interactive workflows.
+
+**Feature area**: Tools, Subagents
+
+**Status**: Confirmed through testing
+
+---
+
+## How to Add Observations
+
+When you discover something undocumented about Claude Code:
+
+1. Describe the observation clearly
+2. Note when and how you discovered it
+3. Explain the practical implication
+4. Identify the feature area (Tools, Subagents, Skills, Hooks, etc.)
+
+The skill will help you format and submit this as a GitHub issue for tracking.

--- a/plugins/meta-claude/skills/self-documentation/references/topic-index.md
+++ b/plugins/meta-claude/skills/self-documentation/references/topic-index.md
@@ -1,0 +1,54 @@
+# Topic Index
+
+Lightweight keyword-to-file mapping for efficient reference lookups. Load this file first to identify which reference file(s) to read.
+
+## Keyword Mapping
+
+| Keywords | Reference File | Description |
+|----------|----------------|-------------|
+| skill, skills, SKILL.md, allowed-tools, user-invocable, skill hooks | core-features.md | Skills system |
+| agent, subagent, Task tool, delegate, fork, context | core-features.md | Agents and subagents |
+| mcp, server, protocol, tool, mcp server, model context protocol | core-features.md | MCP servers |
+| plugin, marketplace, install plugin, plugin update | core-features.md | Plugins |
+| slash command, /command, user-defined command | core-features.md | Slash commands |
+| hook, hooks, PreToolUse, PostToolUse, Stop, Notification | core-features.md | Hooks system |
+| CLAUDE.md, memory, context, project instructions | configuration.md | Memory management |
+| rules, .claude/rules, modular rules | configuration.md | Modular rules |
+| permission, permissions, allow, deny, tool access | configuration.md | Permission management |
+| sandbox, sandboxing, docker, isolation | configuration.md | Sandboxing |
+| model, claude-sonnet, claude-opus, haiku, model selection | configuration.md | Model configuration |
+| output, style, streaming, markdown | configuration.md | Output styles |
+| status line, statusLine, prompt | configuration.md | Status line customization |
+| vscode, vs code, ide, extension | integrations.md | VS Code extension |
+| azure, foundry, enterprise | integrations.md | Azure AI Foundry |
+| keyboard, shortcut, interactive, ctrl, alt, readline | workflows.md | Interactive mode |
+| checkpoint, rewind, undo, restore | workflows.md | Checkpointing |
+| cost, usage, tokens, spending | workflows.md | Cost tracking |
+| git, branch, commit, pr, pull request | workflows.md | Git automation |
+| parallel, concurrent, background | workflows.md | Parallel execution |
+| session, named session, resume | workflows.md | Named sessions |
+| should I use, when to use, vs, versus, difference, compare, choose | decision-guide.md | Feature decisions |
+| skill vs, agent vs, mcp vs, slash command vs | decision-guide.md | Feature comparisons |
+| release notes, undocumented, new feature, recent | undocumented.md | Undocumented features |
+| explore subagent, LSP, desktop, chrome extension | undocumented.md | Specific undocumented features |
+| observation, discovered, tested, behavior, found that | observations.md | User observations |
+
+## Cross-Theme Questions
+
+Some questions span multiple themes. Load multiple files when keywords match different categories:
+
+- "How do skills work with MCP servers?" → core-features.md (both topics)
+- "Should I use a skill or subagent for this?" → decision-guide.md + core-features.md
+- "What permissions does my MCP server need?" → core-features.md + configuration.md
+
+## File Purposes
+
+| File | Primary Use |
+|------|-------------|
+| `core-features.md` | "How does X work?" for fundamental features |
+| `configuration.md` | "How do I configure/customize X?" |
+| `integrations.md` | IDE and platform-specific questions |
+| `workflows.md` | Productivity and workflow optimization |
+| `decision-guide.md` | "Should I use X or Y?" comparisons |
+| `undocumented.md` | Features not yet in official docs |
+| `observations.md` | User-discovered behaviors |

--- a/plugins/meta-claude/skills/self-documentation/references/undocumented.md
+++ b/plugins/meta-claude/skills/self-documentation/references/undocumented.md
@@ -1,0 +1,392 @@
+# Undocumented Features
+
+Features mentioned in Claude Code release notes but not yet covered in official documentation. Information is based on release note descriptions and behavioral understanding. Details may be incomplete or subject to change.
+
+**Latest Release**: v2.0.74 (as of 2025-12-22)
+
+---
+
+## Explore Subagent
+
+**What it is**: Built-in Haiku-powered subagent for efficient codebase exploration and searching
+
+**Introduced**: v2.0.17 (2025-02)
+
+**What we know**:
+- Automatically invoked when main Claude needs to search through codebase
+- Uses Haiku model for speed and context efficiency
+- Designed to answer questions like "Where are errors handled?" or "How does authentication work?"
+- Has access to Glob, Grep, and Read tools for codebase navigation
+- Operates in separate context window to preserve main conversation tokens
+
+**Likely trigger patterns**:
+- Questions about code location ("Where is X defined?")
+- Architectural questions ("How does Y work?")
+- Pattern discovery ("Find all instances of Z")
+- Codebase exploration without specific file paths
+
+**Unanswered questions**:
+- Exact description/trigger conditions used for automatic invocation
+- Full list of available tools
+- Whether it can be explicitly invoked or customized
+
+---
+
+## AskUserQuestion Tool
+
+**What it is**: Tool enabling Claude to ask structured multiple-choice questions during conversations
+
+**Introduced**: v2.0.21 (2025-03)
+
+**What we know**:
+- Allows Claude to present questions with structured options
+- Supports multi-select (choose multiple answers) and single-select modes
+- Particularly active in plan mode
+- Questions include header (short label), main question text, and 2-4 options
+- Each option has label and description explaining implications
+- "Other" option automatically provided for custom input
+
+**Typical use cases**:
+- Plan mode: "Which approach do you prefer for authentication?"
+- Implementation choices: "Which library should we use?"
+- User preference gathering: "What features should I prioritize?"
+- Clarifying ambiguous requirements before implementation
+
+**Unanswered questions**:
+- Full parameter schema and capabilities
+- How Claude decides when to ask vs. make assumptions
+- Whether users can configure question frequency
+
+---
+
+## Ctrl-G External Editor
+
+**What it is**: Keyboard shortcut to edit prompts in system's configured text editor
+
+**Introduced**: v2.0.10 (2024-12)
+
+**What we know**:
+- Press Ctrl-G to open current prompt in external editor
+- Useful for composing long or complex prompts
+- Likely uses $EDITOR or $VISUAL environment variables
+
+**Expected workflow**:
+1. Start typing prompt in Claude Code
+2. Press Ctrl-G to open in editor
+3. Compose/edit in full editor (Vim, VS Code, nano, etc.)
+4. Save and close editor
+5. Content returns to Claude Code prompt
+
+---
+
+## @-mention to Toggle MCP Servers
+
+**What it is**: Enable or disable MCP servers by @-mentioning their names
+
+**Introduced**: v2.0.10 (2024-12), refined in v2.0.14
+
+**What we know**:
+- @-mention an MCP server name to toggle its enabled/disabled state
+- Alternative to using `/mcp` menu for quick server management
+- Provides visual confirmation of new state
+
+**Practical uses**:
+- Quickly disable expensive MCP servers when not needed
+- Enable specialized servers only for specific tasks
+- Manage token usage by controlling active tools
+
+---
+
+## Auto-background Long-running Bash Commands
+
+**What it is**: Automatic backgrounding of bash commands that exceed timeout instead of killing them
+
+**Introduced**: v2.0.19 (2025-03)
+
+**What we know**:
+- Long-running commands automatically move to background instead of timing out
+- Controlled by BASH_DEFAULT_TIMEOUT_MS environment variable
+- Complements manual Ctrl-B backgrounding feature
+
+**Behavior change**:
+- **Before v2.0.19**: Commands hitting timeout were terminated
+- **After v2.0.19**: Commands hitting timeout automatically background
+- Claude can continue working while command runs
+- Output can be checked later via BashOutput tool
+
+**Configuration**:
+- Set `BASH_DEFAULT_TIMEOUT_MS` to control timeout threshold
+- Default appears to be 120000ms (2 minutes)
+- `BASH_MAX_TIMEOUT_MS` sets maximum allowed timeout
+
+---
+
+## MCP structuredContent Field Support
+
+**What it is**: Support for structured content in MCP tool responses beyond plain text
+
+**Introduced**: v2.0.21 (2025-03)
+
+**What we know**:
+- MCP servers can now return `structuredContent` field in tool responses
+- Enables richer tool outputs with formatting, hierarchy, or specialized data structures
+- Part of Model Context Protocol specification
+
+**Likely capabilities**:
+- Structured data formats (JSON, tables, lists)
+- Rich formatting (bold, italic, code blocks)
+- Hierarchical content organization
+
+---
+
+## MCP headersHelper Configuration
+
+**What it is**: Dynamic header generation for MCP servers via helper script
+
+**Introduced**: v1.0.119 (2025-01)
+
+**What we know**:
+- Configure `headersHelper` in MCP server config to run a script that outputs HTTP headers
+- Script outputs JSON with header key-value pairs
+- Enables OAuth token refresh, short-lived API keys, and dynamic authentication
+
+**Configuration**:
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "...",
+      "headersHelper": "/path/to/script.sh"
+    }
+  }
+}
+```
+
+---
+
+## CLAUDE_BASH_NO_LOGIN Environment Variable
+
+**What it is**: Skip login shell initialization for faster bash command execution
+
+**Introduced**: v1.0.124 (2025-02)
+
+**What we know**:
+- Set `CLAUDE_BASH_NO_LOGIN=1` to skip loading .bash_profile, .profile, etc.
+- Trade-off: faster execution but may miss custom aliases, functions, PATH entries
+- Useful for simple commands, containers, or performance-critical workflows
+
+---
+
+## Auto-Allowed Tools
+
+**What it is**: Pre-approved tools that bypass permission prompts for common, safe operations
+
+**Introduced**: Permission system (v1.0.7+)
+
+**What we know**:
+- Certain tool patterns auto-approve in "Ask" permission mode
+- Configured in settings.json `permissions.allow` arrays
+- Common patterns: WebSearch, safe bash commands (git log, npm test), WebFetch for documentation domains, MCP read operations
+- Users can override with explicit Deny rules
+- Project settings can add project-specific allowed patterns
+
+---
+
+## Bash Permission Rule Matching
+
+**What it is**: Advanced pattern matching rules for Bash tool permissions including output redirection handling
+
+**Introduced**: Core permission system, enhanced in v1.0.123 (output redirection)
+
+**What we know**:
+- Permission rules support sophisticated pattern matching
+- System prompt indicates: "Bash permission rules now support output redirections when matching"
+- Example: `Bash(python:*)` matches `python script.py > output.txt`
+
+**Pattern matching details**:
+- Wildcard support: `Bash(git:*)` matches all git commands
+- Output redirection awareness: Rules match command before redirect operators
+- Environment variable handling: Inline env vars in commands
+
+**Rule format examples**:
+- `Bash(git push:*)` - Allow all git push variations
+- `Bash(npm run test:*)` - Allow all test scripts
+- `Bash(python:*)` - Allow python commands (including output redirection)
+
+---
+
+## SubagentStart Hook Event
+
+**What it is**: Hook event that fires when a subagent begins execution
+
+**Introduced**: v2.0.43 (2025-11)
+
+**What we know**:
+- New hook event type added to the existing hook events
+- Complements existing `SubagentStop` hook for complete subagent lifecycle monitoring
+- Enables custom automation at subagent initialization
+
+**Expected use cases**:
+- Logging/monitoring when specific subagents activate
+- Pre-execution validation or setup for subagent tasks
+- Custom initialization logic before subagent begins work
+
+---
+
+## Custom Agent permissionMode Field
+
+**What it is**: Configuration field controlling permission behavior for specific custom agents
+
+**Introduced**: v2.0.43 (2025-11)
+
+**What we know**:
+- New frontmatter field for custom agent definitions
+- Allows per-agent permission policies independent of global settings
+- Likely controls auto-approve, ask, or deny behavior for agent's tool usage
+
+**Example configuration**:
+```yaml
+---
+name: trusted-test-runner
+description: Run test suites without permission prompts
+permissionMode: allow
+tools: Bash
+---
+```
+
+---
+
+## Subagent Skills Frontmatter Field
+
+**What it is**: Configuration to auto-load specific skills when a subagent activates
+
+**Introduced**: v2.0.43 (2025-11)
+
+**What we know**:
+- New frontmatter field: `skills: skill-name-1, skill-name-2`
+- Skills load when subagent activates, unload when it completes
+- Enables specialized expertise per subagent without global loading
+
+**Example**:
+```yaml
+---
+name: code-reviewer
+description: Review code changes
+skills: code-quality-standards, security-patterns
+---
+```
+
+---
+
+## Web Background Tasks with & Syntax
+
+**What it is**: Send long-running tasks to Claude Code web by prefixing messages with `&`
+
+**Introduced**: v2.0.45 (2025-11)
+
+**What we know**:
+- Start message with `&` in CLI to transfer task to web interface
+- Enables continuing CLI work while task runs on web
+- Similar to Ctrl-B (background bash) but cross-platform
+
+---
+
+## Opus 4.5 Model
+
+**What it is**: Claude's newest frontier model with enhanced capabilities
+
+**Introduced**: v2.0.51 (2025-11), Pro access added v2.0.58 (2025-12)
+
+**What we know**:
+- Model ID: `claude-opus-4-5-20251101`
+- Accessible via `/model` selector or `--model opus`
+- Thinking mode enabled by default for Opus 4.5 (v2.0.67)
+- Pro users have full access included in subscription
+
+**Model selection context**:
+- Fits into existing model hierarchy: haiku (fast), sonnet (balanced), opus (complex reasoning)
+- `opus` alias now defaults to Opus 4.5
+- Works with opusplan mode (opus for planning, sonnet for execution)
+- Thinking mode can be toggled with Alt+T (sticky across sessions)
+
+---
+
+## LSP Tool (Language Server Protocol)
+
+**What it is**: Code intelligence tool for go-to-definition, find references, and hover documentation
+
+**Introduced**: v2.0.74 (2025-12)
+
+**What we know**:
+- Leverages language servers for semantic code understanding
+- Capabilities: go-to-definition, find references, hover documentation/types
+- More accurate than grep - understands code structure and types
+- Complements Glob and Grep with semantic search
+
+**Likely supported languages**: TypeScript/JavaScript, Python, other LSP-compatible languages
+
+---
+
+## fileSuggestion Setting
+
+**What it is**: Configuration to customize the `@` file search behavior with custom commands
+
+**Introduced**: v2.0.65 (2025-12)
+
+**What we know**:
+- New `fileSuggestion` setting in settings.json
+- Enables customizing how `@` file suggestions work
+- Can use external tools like `fzf`, `fd`, or custom scripts
+
+**Expected configuration**:
+```json
+{
+  "fileSuggestion": {
+    "command": "fd --type f"
+  }
+}
+```
+
+---
+
+## CLAUDE_CODE_SHELL Environment Variable
+
+**What it is**: Environment variable to override automatic shell detection
+
+**Introduced**: v2.0.65 (2025-12)
+
+**What we know**:
+- Set `CLAUDE_CODE_SHELL` to specify shell executable
+- Useful when login shell differs from preferred working shell
+- Helps with environments where shell detection fails
+
+**Configuration example**:
+```bash
+export CLAUDE_CODE_SHELL=/bin/zsh
+```
+
+---
+
+## Integration Pattern: Skills + Subagents
+
+**Problem**: You want specialized knowledge available for both user questions AND automation workflows, without duplicating logic.
+
+**Solution**: Create a skill with the expertise, configure subagent to auto-load it.
+
+**Example: npm-update-advisor + package-updater**
+
+```yaml
+# Skill: Contains npm diagnostic logic
+name: npm-update-advisor
+description: Analyzes npm update strategies based on semver, lock files...
+
+# Subagent: Orchestrates package updates, loads skill
+name: package-updater
+skills: npm-update-advisor
+tools: Bash, Read
+```
+
+**Result:**
+- User asks npm questions → Skill triggers in main conversation
+- Security automation runs → Subagent loads skill for smart decisions
+- Single source of truth, dual contexts

--- a/plugins/meta-claude/skills/self-documentation/references/workflows.md
+++ b/plugins/meta-claude/skills/self-documentation/references/workflows.md
@@ -1,0 +1,172 @@
+# Workflows
+
+Productivity features, keyboard shortcuts, and workflow automation in Claude Code.
+
+**Last updated**: 2025-01-09
+
+---
+
+## Interactive Mode & Keyboard Shortcuts
+
+**What it is**: Terminal interface controls for navigation, editing, and workflow management with extensive keyboard shortcuts
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/interactive-mode
+
+**Key concepts**:
+- **General controls**: Ctrl+C (interrupt), Ctrl+D (exit), Ctrl+L (clear screen), Ctrl+O (toggle verbose/transcript), Ctrl+R (history search), Ctrl+V/Alt+V (paste images), Tab (thinking toggle), Shift+Tab/Alt+M (permission modes)
+- **Multiline entry**: `\` + Enter, Option+Enter (macOS), Shift+Enter (after /terminal-setup)
+- **Quick commands**: `#` (add to memory), `/` (slash commands), `!` (direct bash), `@` (file autocomplete)
+- **Vim mode**: Standard navigation (h/j/k/l, w, b) and editing (dd, cc, x) with Esc mode switching
+- **Command history**: Per-directory storage with Ctrl+R interactive search and highlighting
+- **Background tasks**: Ctrl+B to run long processes asynchronously with output buffering via BashOutput tool
+- **Bash mode**: `!` prefix bypasses Claude's interpretation while maintaining conversation context
+- **Kill ring** (v2.0.49+): Ctrl-Y yanks most recent deletion, Alt-Y cycles through older deletions
+- **Model switching** (v2.0.65+): Alt+P (Linux/Windows) or Option+P (macOS) to switch models mid-prompt
+
+---
+
+## Checkpointing & Rewind
+
+**What it is**: Automatic file state tracking with ability to rewind conversation and/or code changes to previous points
+
+**Documentation**: https://docs.anthropic.com/en/docs/claude-code/checkpointing
+
+**Key concepts**:
+- **Automatic tracking**: Every user prompt creates a checkpoint; persists across sessions
+- **Access**: Press Escape twice or type `/rewind` to open restoration menu
+- **Three restoration options**: Conversation only (keeps code), Code only (keeps conversation), Both (full rewind)
+- **Use cases**: Experiment with implementations, recover from bugs, iterate while maintaining stable states
+- **Limitations**: Does not track Bash command modifications (rm, mv, cp), external file changes, or concurrent session edits
+- **Automatic cleanup**: Checkpoints clean up after 30 days (configurable)
+- **Complementary to Git**: Designed for quick session-level recovery, not replacement for version control
+
+---
+
+## Git Workflow Automation
+
+**What it is**: Standardized patterns for commit creation and pull request workflows with safety checks
+
+**Key concepts**:
+- Uses Conventional Commits format: `type(scope): subject`
+- Automatic co-authoring with Claude
+- Multiple safety checks and git best practices
+
+**Commit creation workflow**:
+1. Run `git status`, `git diff`, `git log` **in parallel** to understand context
+2. Analyze all staged changes and draft commit message
+3. Validate commit message follows conventions (type, scope, subject)
+4. Add untracked files, create commit with heredoc format, run `git status` after
+5. If pre-commit hook modifies files, verify safety to amend (authorship check, not pushed)
+
+**PR creation workflow**:
+1. Run `git status`, `git diff`, check remote tracking **in parallel**
+2. Run `git log` and `git diff [base-branch]...HEAD` to understand full branch history
+3. Analyze **all commits** in branch (not just latest)
+4. Create PR with format: Summary (1-3 bullets), Test plan (checklist), Claude attribution
+
+**Safety protocols**:
+- Never update git config
+- Never force push to main/master (warn if requested)
+- Never skip hooks (--no-verify) unless explicitly requested
+- Only amend commits if: (1) user explicitly requested OR (2) adding pre-commit edits
+- Always check authorship before amending: `git log -1 --format='%an %ae'`
+- Never commit unless explicitly asked
+
+---
+
+## Parallel Execution
+
+**What it is**: Concurrent execution of multiple independent tool calls or subagents in a single message for efficiency
+
+**Key concepts**:
+- Claude sends multiple independent tool calls in one message when safe to do so
+- User can request "run agents in parallel" for concurrent subagent execution
+- Each parallel call executes concurrently; all must complete before Claude continues
+- Critical constraint: Never parallelize dependent operations (e.g., Read before Edit)
+
+**Common patterns**:
+- **Git pre-commit**: `git status`, `git diff`, `git log` together
+- **Multi-file reads**: Several `Read` calls for different files
+- **Parallel agents**: `code-reviewer` + `test-runner` simultaneously
+- **Codebase search**: Multiple `Grep` with different patterns
+
+**Constraints**:
+- Never use placeholders or guess parameters - wait for actual values
+- Sequential dependencies require sequential calls
+- Results from all calls needed before continuing
+
+---
+
+## Background Agent Support
+
+**What it is**: Ability for agents to run in the background while you continue working, with asynchronous message passing
+
+**Introduced**: v2.0.60 (2025-12)
+
+**What we know**:
+- Agents can now run in background while user continues working
+- Agents and bash commands can run asynchronously and send messages to wake up the main agent
+- Enables true parallel workflows with human and agent working simultaneously
+
+**Expected behavior**:
+- Start an agent task that runs in background
+- Continue typing/working on other tasks
+- Agent can send messages to notify main agent when done
+- Results become available when background work completes
+
+**Use cases**:
+- Long-running analysis tasks
+- Test suites running while implementing next feature
+- Documentation generation in background
+- Complex search/exploration while coding
+
+---
+
+## Named Sessions
+
+**What it is**: Ability to name conversation sessions for easier resumption and organization
+
+**Introduced**: v2.0.64 (2025-12)
+
+**What we know**:
+- Use `/rename` to name current session
+- Use `/resume <name>` in REPL to resume named session
+- Use `claude --resume <name>` from terminal to resume
+- Makes session management more intuitive than using session IDs
+
+**Workflow examples**:
+```bash
+# In Claude Code session:
+/rename feature-auth-refactor
+
+# Later, resume from terminal:
+claude --resume feature-auth-refactor
+
+# Or resume from within Claude Code:
+/resume feature-auth-refactor
+```
+
+**Benefits**:
+- Human-readable session identifiers
+- Easy switching between work contexts
+- Better organization of related work
+- No need to remember cryptic session IDs
+
+---
+
+## /stats Command
+
+**What it is**: Command to view interesting Claude Code usage statistics including graphs and streaks
+
+**Introduced**: v2.0.64 (2025-12)
+
+**What we know**:
+- New `/stats` command provides usage statistics
+- Shows personal usage patterns and metrics
+- May include visual graphs and streak tracking
+
+**Expected metrics**:
+- Favorite/most-used model
+- Usage over time (graph)
+- Usage streak (consecutive days)
+- Possibly token counts, session counts, etc.


### PR DESCRIPTION
## Summary

Adds a comprehensive self-documentation skill to the meta-claude plugin that enables Claude Code to explain its own features, guide architectural decisions, and record undocumented observations. Provides interactive capability guidance and maintains a progressive-disclosure reference structure for token-efficient learning.

## Changes

- New self-documentation skill enabling interactive feature explanations and decision guidance
- 8 thematic reference files (core features, workflows, integrations, configuration, undocumented behaviors, observations, decision guide, topic index)
- Observation recording workflow with GitHub issue creation
- Version bump: meta-claude 1.1.0 → 1.2.0
- Updated marketplace and README documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)