### PR TITLE
feat(meta-claude): add Agent SDK data source for self-documentation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "meta-claude",
       "source": "./plugins/meta-claude",
       "description": "Claude Code productivity skills: session export, self-documentation for explaining features and capabilities, and self-reflection tools",
-      "version": "1.2.3"
+      "version": "1.3.0"
     }
   ]
 }

--- a/.claude/agents/documentation-updater.md
+++ b/.claude/agents/documentation-updater.md
@@ -26,8 +26,12 @@ You maintain the reference files in `plugins/meta-claude/skills/self-documentati
 | `references/integrations.md` | VS Code, IDE extensions |
 | `references/workflows.md` | Shortcuts, git automation |
 | `references/topic-index.md` | Keyword-to-file mapping |
+| `references/sdk-behavioral-bridges.md` | Behavioral info from Agent SDK |
+| `references/observations.md` | User-discovered behaviors |
 
-## Official Documentation
+## Data Sources
+
+### Claude Code Documentation
 
 **Index:** `https://code.claude.com/docs/llms.txt`
 
@@ -46,6 +50,27 @@ Examples:
 2. Search for the feature name in the index
 3. If found, fetch that page to get details
 4. If not found, the feature is undocumented
+
+### Agent SDK Documentation
+
+**Base URL:** `https://platform.claude.com/docs/en/agent-sdk/`
+
+The Agent SDK docs contain behavioral information that explains Claude Code CLI behavior but isn't in the Claude Code docs. Use this source for behavioral constraints.
+
+**Key pages for behavioral info:**
+- `/user-input` - AskUserQuestion constraints (timeouts, limits, subagent restrictions)
+- `/permissions` - Permission evaluation flow
+- `/subagents` - Subagent limitations
+- `/hooks` - Hook availability (TypeScript vs Python)
+- `/sessions` - Fork behavior
+- `/file-checkpointing` - What file changes are tracked
+- `/skills` - SDK vs CLI differences
+- `/mcp` - Tool naming conventions
+
+**When to check SDK docs:**
+- New features involving subagents, permissions, or tools
+- Features with "unanswered questions" in undocumented.md
+- User observations that might have SDK documentation
 
 ## Release Notes Format
 
@@ -112,6 +137,22 @@ For each new feature from release notes:
 3. **If undocumented:**
    - Add to `undocumented.md` using the entry format below
 
+### Step 4b: Check Agent SDK for Behavioral Updates
+
+For features that might have SDK-documented behavior:
+
+1. Identify features involving subagents, permissions, tools, or sessions
+2. Fetch relevant SDK page via WebFetch (e.g., `/user-input` for AskUserQuestion)
+3. Extract behavioral constraints and limitations
+4. If new behavioral info found:
+   - Update `sdk-behavioral-bridges.md` with the information
+   - Add cross-reference in `undocumented.md` if feature is there
+   - Add keywords to `topic-index.md`
+
+**Also check:** If `observations.md` has entries that are now documented in SDK docs:
+- Migrate the observation to `sdk-behavioral-bridges.md`
+- Update `observations.md` to note the migration
+
 ### Step 5: Write Changes
 
 Update files directly:
@@ -169,8 +210,11 @@ When a feature has official docs, read the content and match:
 | Settings, permissions, CLAUDE.md, sandboxing, model config | configuration.md |
 | VS Code, IDE, extensions, Azure, Foundry | integrations.md |
 | Keyboard, shortcuts, git, sessions, checkpoints, cost | workflows.md |
+| SDK behavioral constraints, limitations, timeouts, tool availability | sdk-behavioral-bridges.md |
 
 **Default:** If unclear, use `core-features.md` and note "categorization may need review"
+
+**SDK content:** Information from Agent SDK docs goes to `sdk-behavioral-bridges.md`, not thematic files
 
 ## Entry Formats
 
@@ -210,6 +254,20 @@ Brief description with key concepts.
 Add keyword mappings:
 ```markdown
 | feature-keyword, related-term | target-file.md | Brief description |
+```
+
+### For sdk-behavioral-bridges.md
+
+```markdown
+## Feature/Constraint Name
+
+**Source**: /docs/en/agent-sdk/<page>
+
+**Behavioral Constraints**:
+- Constraint or limitation
+- With practical implications
+
+**Implication**: How this affects CLI usage
 ```
 
 ## Efficiency Guidelines
@@ -256,6 +314,7 @@ Before finishing:
 - [ ] All new features from release notes are accounted for
 - [ ] "Latest Release" header updated to newest version
 - [ ] Documented features **removed** from `undocumented.md` (not just updated)
+- [ ] SDK-documented observations migrated to `sdk-behavioral-bridges.md`
 - [ ] New keywords added to `topic-index.md`
 - [ ] Entry formats are consistent with existing entries
 - [ ] Plugin version bumped (patch for doc updates)

--- a/plugins/meta-claude/.claude-plugin/plugin.json
+++ b/plugins/meta-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meta-claude",
   "description": "Claude Code productivity skills: session export, self-documentation for explaining features and capabilities, and self-reflection tools",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/meta-claude/skills/self-documentation/SKILL.md
+++ b/plugins/meta-claude/skills/self-documentation/SKILL.md
@@ -31,6 +31,7 @@ The skill uses thematic reference files for token-efficient progressive disclosu
 | `workflows.md` | Keyboard shortcuts, checkpointing, git automation |
 | `undocumented.md` | Features from release notes without official docs |
 | `observations.md` | User-discovered behaviors |
+| `sdk-behavioral-bridges.md` | Behavioral constraints from Agent SDK docs |
 
 ## Workflow: Answering Questions
 
@@ -51,6 +52,8 @@ Read the identified reference file(s). Only load what's needed - avoid loading a
 If the reference file includes a documentation URL and more detail is needed:
 1. Use WebFetch to retrieve the official documentation
 2. Synthesize with reference file content
+
+**For behavioral constraints:** Check `sdk-behavioral-bridges.md` for authoritative information from the Agent SDK docs (e.g., tool limitations, permission flow, subagent constraints).
 
 ### Step 5: Respond
 

--- a/plugins/meta-claude/skills/self-documentation/references/observations.md
+++ b/plugins/meta-claude/skills/self-documentation/references/observations.md
@@ -2,25 +2,17 @@
 
 User-discovered behaviors and findings not documented in official Claude Code documentation. These observations come from hands-on testing and community contributions.
 
+**Note**: Some observations may later be confirmed by SDK documentation. When this happens, the observation is migrated to `sdk-behavioral-bridges.md` with proper attribution.
+
 **How to contribute**: When you discover undocumented behavior, use this skill to record it. The skill will create a GitHub issue and optionally cache locally.
 
 ---
 
-## AskUserQuestion Cannot Be Delegated to Subagents
+## Migrated Observations
 
-**Observation**: The AskUserQuestion tool cannot be used when running in a forked/subagent context via the Task tool.
+The following observations have been confirmed by SDK documentation and moved to `sdk-behavioral-bridges.md`:
 
-**Discovered**: 2025-01-09
-
-**Context**: Attempted to create an interactive skill that runs in forked context (`context: fork`) to ask users questions during execution.
-
-**Behavior**: When a subagent attempts to use AskUserQuestion, the tool is not available or fails. Interactive questioning only works in the main conversation context.
-
-**Implication**: Skills that need to ask users questions must run in the main context, not as forked subagents. Use `context: fork` only for non-interactive workflows.
-
-**Feature area**: Tools, Subagents
-
-**Status**: Confirmed through testing
+- **AskUserQuestion Cannot Be Delegated to Subagents** (discovered 2026-01-09) → See `sdk-behavioral-bridges.md` for authoritative documentation
 
 ---
 

--- a/plugins/meta-claude/skills/self-documentation/references/sdk-behavioral-bridges.md
+++ b/plugins/meta-claude/skills/self-documentation/references/sdk-behavioral-bridges.md
@@ -1,0 +1,187 @@
+# SDK Behavioral Bridges
+
+Last updated: 2026-01-11
+Source: Agent SDK Documentation (platform.claude.com/docs/en/agent-sdk/)
+
+Information from the Agent SDK documentation that explains Claude Code CLI behavior. This file bridges SDK documentation with CLI usage, extracting behavioral constraints that affect how Claude Code works.
+
+---
+
+## AskUserQuestion Tool
+
+**Source**: /docs/en/agent-sdk/user-input
+
+**Behavioral Constraints**:
+- 60-second timeout for responses
+- 1-4 questions per call
+- 2-4 options per question
+- **Not available in subagents** spawned via Task tool
+
+**Implication**: Interactive skills must run in main context, not forked. Use `context: fork` only for non-interactive workflows.
+
+---
+
+## Permission Evaluation Flow
+
+**Source**: /docs/en/agent-sdk/permissions
+
+**Order of evaluation**:
+1. Hooks (can allow, deny, or continue)
+2. Permission rules (deny → allow → ask)
+3. Permission mode (bypassPermissions, acceptEdits, dontAsk, default)
+4. canUseTool callback (if not resolved above)
+
+**Key insight**: Deny rules are checked first - any match results in immediate denial, regardless of allow rules.
+
+---
+
+## Subagent Constraints
+
+**Source**: /docs/en/agent-sdk/subagents
+
+**Behavioral Constraints**:
+- Cannot spawn their own subagents (no Task tool in subagent tools)
+- Cannot use AskUserQuestion
+- Messages include `parent_tool_use_id` field for tracking
+
+**Implication**: Subagent depth is limited to 1 level. Design workflows that don't require nested delegation.
+
+---
+
+## MCP Tool Naming
+
+**Source**: /docs/en/agent-sdk/mcp
+
+**Convention**: `mcp__<server_name>__<tool_name>`
+
+**Examples**:
+- Server "playwright" → `mcp__playwright__browser_click`
+- Server "linear" → `mcp__linear__create_issue`
+
+The server name comes from the key used in MCP server configuration.
+
+---
+
+## File Checkpointing Scope
+
+**Source**: /docs/en/agent-sdk/file-checkpointing
+
+**What's tracked** (can be reverted):
+- Write tool
+- Edit tool
+- NotebookEdit tool
+
+**What's NOT tracked** (permanent changes):
+- Bash commands (echo, sed, cat, etc.)
+- Directory operations
+- Remote files
+
+**Implication**: For revertible file operations, use Write/Edit tools. Changes made via Bash are permanent and cannot be rewound using checkpoints.
+
+---
+
+## Skills Tool Restrictions
+
+**Source**: /docs/en/agent-sdk/skills
+
+**Important difference between CLI and SDK**:
+- `allowed-tools` frontmatter in SKILL.md only works in CLI
+- SDK ignores skill-level tool restrictions
+- SDK controls tools via `allowedTools` option in query configuration
+
+**Implication**: Skills designed with tool restrictions work as expected in CLI but may have broader tool access in SDK applications.
+
+---
+
+## Session Fork Behavior
+
+**Source**: /docs/en/agent-sdk/sessions
+
+**Fork vs Continue**:
+
+| Behavior | `forkSession: false` (default) | `forkSession: true` |
+|----------|-------------------------------|---------------------|
+| Session ID | Same as original | New ID generated |
+| History | Appends to original | Creates new branch |
+| Original session | Modified | Preserved unchanged |
+| Use case | Continue linear conversation | Explore alternatives |
+
+**Implication**: Use fork when you want to try different approaches from the same starting point without modifying the original session.
+
+---
+
+## Hook Availability
+
+**Source**: /docs/en/agent-sdk/hooks
+
+**TypeScript-only hooks** (not available in Python SDK):
+- SessionStart
+- SessionEnd
+- Notification
+- SubagentStart
+- PostToolUseFailure
+- PermissionRequest
+
+**Hook execution order** (when multiple hooks match):
+1. Deny decisions checked first (any match = immediate denial)
+2. Ask rules checked second
+3. Allow rules checked third
+4. Default to Ask if nothing matches
+
+---
+
+## Streaming Input Requirements
+
+**Source**: /docs/en/agent-sdk/streaming-vs-single-mode
+
+**Features requiring streaming input mode**:
+- Image attachments in messages
+- Dynamic message queueing
+- Real-time interruption
+- Hook integration
+- MCP server connections
+
+**Single message mode limitations**:
+- No image attachments
+- No hooks
+- No MCP tools
+- Stateless operation only
+
+**Implication**: For full Claude Code functionality, streaming mode is preferred.
+
+---
+
+## Built-in Tools Reference
+
+**Source**: /docs/en/agent-sdk/overview
+
+**Standard tools available**:
+
+| Tool | Purpose |
+|------|---------|
+| Read | Read files from filesystem |
+| Write | Create new files |
+| Edit | Modify existing files |
+| Bash | Run terminal commands |
+| Glob | Find files by pattern |
+| Grep | Search file contents with regex |
+| WebSearch | Search the web |
+| WebFetch | Fetch and parse web content |
+| AskUserQuestion | Ask user questions (constraints above) |
+| Task | Invoke subagents |
+| Skill | Invoke skills |
+| TodoWrite | Manage task lists |
+| NotebookEdit | Edit Jupyter notebooks |
+
+---
+
+## How to Use This File
+
+This reference is for understanding behavioral constraints that come from SDK documentation but affect CLI usage. When you encounter unexpected behavior related to:
+
+- Tool availability in subagents
+- Permission handling
+- File tracking and rewind
+- Session management
+
+Check this file for authoritative documentation from the Agent SDK.

--- a/plugins/meta-claude/skills/self-documentation/references/topic-index.md
+++ b/plugins/meta-claude/skills/self-documentation/references/topic-index.md
@@ -41,6 +41,15 @@ Lightweight keyword-to-file mapping for efficient reference lookups. Load this f
 | release notes, undocumented, new feature, recent | undocumented.md | Undocumented features |
 | explore subagent, LSP, desktop, chrome extension, IS_DEMO | undocumented.md | Specific undocumented features |
 | observation, discovered, tested, behavior, found that | observations.md | User observations |
+| sdk, agent-sdk, behavioral, limitations | sdk-behavioral-bridges.md | SDK documentation that explains CLI behavior |
+| timeout, 60 seconds, canUseTool | sdk-behavioral-bridges.md | Tool and callback timeouts |
+| permission flow, evaluation order, deny first | sdk-behavioral-bridges.md | How permissions are evaluated |
+| fork session, forkSession, session branch | sdk-behavioral-bridges.md | Session forking behavior |
+| checkpoint scope, rewind scope, tracked changes | sdk-behavioral-bridges.md | File checkpointing limitations |
+| mcp naming, tool naming, mcp__ | sdk-behavioral-bridges.md | MCP tool naming convention |
+| subagent depth, nested subagent, Task in subagent | sdk-behavioral-bridges.md | Subagent spawning constraints |
+| streaming mode, single message, image upload | sdk-behavioral-bridges.md | Input mode requirements |
+| TypeScript-only, Python SDK limitations | sdk-behavioral-bridges.md | SDK platform differences |
 
 ## Cross-Theme Questions
 
@@ -64,3 +73,4 @@ Some questions span multiple themes. Load multiple files when keywords match dif
 | `decision-guide.md` | "Should I use X or Y?" comparisons |
 | `undocumented.md` | Features not yet in official docs |
 | `observations.md` | User-discovered behaviors |
+| `sdk-behavioral-bridges.md` | Behavioral constraints from SDK docs |

--- a/plugins/meta-claude/skills/self-documentation/references/undocumented.md
+++ b/plugins/meta-claude/skills/self-documentation/references/undocumented.md
@@ -46,16 +46,18 @@ Features mentioned in Claude Code release notes but not yet covered in official 
 - Each option has label and description explaining implications
 - "Other" option automatically provided for custom input
 
+**Behavioral constraints** (from SDK docs): See `sdk-behavioral-bridges.md` for:
+- 60-second timeout for responses
+- 1-4 questions per call, 2-4 options per question
+- Not available in subagents spawned via Task tool
+
 **Typical use cases**:
 - Plan mode: "Which approach do you prefer for authentication?"
 - Implementation choices: "Which library should we use?"
 - User preference gathering: "What features should I prioritize?"
 - Clarifying ambiguous requirements before implementation
 
-**Unanswered questions**:
-- Full parameter schema and capabilities
-- How Claude decides when to ask vs. make assumptions
-- Whether users can configure question frequency
+**Official Documentation**: Not in Claude Code docs; behavioral details in Agent SDK (/docs/en/agent-sdk/user-input)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Agent SDK documentation as a new reference data source for the self-documentation skill. This enhances the skill's ability to explain behavioral constraints and limitations that Claude Code inherits from the underlying Agent SDK platform.

## Components & Changes

1. **New reference file**: `sdk-behavioral-bridges.md` (187 lines)
   - Extracts behavioral constraints from Agent SDK documentation
   - Covers: AskUserQuestion limitations, permission evaluation flow, subagent constraints, MCP tool naming, file checkpointing scope, session fork behavior, and more
   - Acts as a bridge between SDK platform capabilities and CLI behavior

2. **Updated topic-index.md**: Added 9 keyword mappings
   - Maps SDK-related queries to `sdk-behavioral-bridges` reference
   - Keywords: subagents, AskUserQuestion, timeout, permissions, forks, checkpoints, MCP, naming conventions, constraints

3. **Updated observations.md**: Migrated AskUserQuestion observation
   - Moved from inline to dedicated SDK file with proper citation
   - Maintains cross-reference for consistency

4. **Updated undocumented.md**: Added SDK cross-reference
   - Added notice directing AskUserQuestion queries to sdk-behavioral-bridges

5. **Updated documentation-updater agent**: Added SDK as data source
   - New Step 4b for SDK behavioral updates
   - Establishes workflow for maintaining SDK reference data

6. **Updated SKILL.md**: Added sdk-behavioral-bridges to reference files table
   - Documents new reference file with description and version

7. **Version bump**: meta-claude 1.2.3 → 1.3.0
   - Minor version bump for new capability
   - Marketplace version also updated to match

## Test Plan

- [x] Agent SDK reference file is valid Markdown with proper structure
- [x] Topic index mappings are accurate and comprehensive
- [x] Cross-references between observation, undocumented, and SDK files are consistent
- [x] Documentation-updater agent workflow is clear and actionable
- [x] Plugin version updated correctly (1.2.3 → 1.3.0)
- [x] Marketplace version matches plugin version

🤖 Generated with [Claude Code](https://claude.com/claude-code)