### PR TITLE
feat(pm-workflow): add prd-evaluation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,8 +19,8 @@
     {
       "name": "pm-workflow",
       "source": "./plugins/pm-workflow",
-      "description": "Product management workflow skills: PRD writing and product one-pagers",
-      "version": "1.0.0"
+      "description": "Product management workflow skills: PRD writing, PRD evaluation, and product one-pagers",
+      "version": "1.1.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ Claude Code productivity skills for session management, self-documentation, and 
 
 ### pm-workflow
 
-Product management workflow skills for writing PRDs and product one-pagers.
+Product management workflow skills for writing and evaluating PRDs and product one-pagers.
 
 **Skills included:**
 
 | Skill | Description |
 |-------|-------------|
 | `prd-writing` | Interview users to transform rough product ideas into comprehensive one-pagers for product kick-offs |
+| `prd-evaluation` | Evaluate PRDs from a product leader's perspective, surfacing gaps in reasoning and unstated assumptions |
 
 ## Usage
 
@@ -79,6 +80,7 @@ Once installed, the agents and skills are automatically available. Claude will p
 - Ask to write a PRD or product brief
 - Ask to create a one-pager or kick-off doc
 - Ask to define product requirements
+- Ask to evaluate, review, or critique a PRD
 
 ## Updating
 

--- a/docs/specs/prd-evaluation-skill.md
+++ b/docs/specs/prd-evaluation-skill.md
@@ -1,0 +1,206 @@
+# PRD Evaluation Skill Spec
+
+## Overview
+
+A skill that evaluates PRDs from an experienced product leader's perspective, identifying gaps in reasoning, unstated assumptions, and disconnects between problem and solution. The skill operates as a critical reviewer, treating PRDs like thesis documents where every link in the chain of reasoning must be explicit and justified.
+
+**Core problem:** PRDs often contain "internalized context" - assumptions and connections that exist in the author's mind but never made it to the page. This creates gaps that confuse stakeholders and weaken the case for the initiative.
+
+## Goals
+
+1. Surface missing links in the reasoning chain (problem → hypothesis → scope → metrics)
+2. Identify hidden assumptions that should be stated explicitly
+3. Catch scope items that don't connect to stated goals
+4. Flag claims and statistics without traceable sources
+5. Help users strengthen PRDs before stakeholder review
+
+## Non-Goals
+
+- Enforcing a specific PRD template or structure
+- Evaluating technical feasibility (no codebase access)
+- Providing market research or competitive analysis
+- Rewriting sections (user does the fixing)
+- Tracking changes across evaluation iterations
+
+## User Experience
+
+### Activation
+
+Explicit invocation only. Triggers:
+- "evaluate this PRD"
+- "review my PRD"
+- "critique my PRD"
+- `/prd-evaluation @path/to/prd.md`
+
+### Input
+
+File reference only (`@path/to/prd.md`). The skill reads the PRD document directly.
+
+### Output
+
+Two outputs:
+
+1. **Inline annotations** - Markdown callouts inserted into the PRD document at relevant locations:
+   ```markdown
+   > [!QUESTION] Why will users "naturally discover" this feature? What evidence supports this assumption?
+   ```
+
+2. **Conversation summary** - Overall assessment delivered in chat, including:
+   - Verdict: "Ready for review" / "Needs work" / "Fundamental gaps"
+   - Count of issues by category
+   - Key areas requiring attention
+
+### Interaction Flow
+
+1. User invokes skill with file reference
+2. Skill reads PRD and performs initial analysis
+3. If fundamental flaws exist (weak problem statement, broken reasoning chain):
+   - Stop and surface the core issue
+   - Ask one clarifying question
+   - Wait for user response before continuing
+4. For gaps (missing information):
+   - Stop and ask one clarifying question at a time
+   - User provides answer
+   - Skill continues evaluation
+5. For weak reasoning (present but unconvincing):
+   - Annotate inline without stopping
+6. After full pass, provide conversation summary
+7. Write annotated PRD back to file
+
+Annotations are cleared on each run (fresh evaluation, not diff-aware).
+
+## Evaluation Framework
+
+### Reasoning Chain Analysis
+
+The PRD should read like a thesis. Check each link:
+
+| Link | Question | Red flags |
+|------|----------|-----------|
+| Problem → Hypothesis | Does the proposed solution actually address the stated problem? | Solution solves different problem; problem too vague to evaluate |
+| Hypothesis → Scope | Does every in-scope item map to the proposed approach? | Scope items that don't serve the hypothesis; missing items needed for hypothesis |
+| Goals → Analytics | Can the stated metrics prove/disprove the hypothesis? | Vanity metrics; metrics that don't map to stated goals; unmeasurable outcomes |
+
+### Issue Categories
+
+**Logical Coherence**
+- Missing steps in reasoning
+- Conclusions that don't follow from premises
+- Circular justifications ("we should do X because we need X")
+
+**Assumption Surfacing**
+- Unstated beliefs treated as facts
+- User behavior assumptions without validation
+- Technical or organizational dependencies not mentioned
+
+**Scope Creep Detection**
+- In-scope items with no clear connection to goals
+- "Nice to have" items mixed with core requirements
+- Scope larger than needed to test hypothesis
+
+**Data/Claim Validation**
+- Statistics without sources
+- Vague quantifiers ("most users", "significant improvement")
+- Claims presented as facts without evidence
+
+### Severity Levels
+
+| Severity | Behavior | Examples |
+|----------|----------|----------|
+| **Blocker** | Stop, address before continuing | Problem statement missing or incoherent; reasoning chain fundamentally broken |
+| **Gap** | Stop, ask clarifying question | Key assumption unstated; metric unmeasurable; scope item unexplained |
+| **Weak** | Annotate inline, continue | Claim without source; reasoning unconvincing but present; minor scope creep |
+
+### TBD Handling
+
+Sections explicitly marked as TBD or "to be researched" are acknowledged but not critiqued. The evaluation focuses on content that is presented as complete.
+
+## Annotation Format
+
+Use Markdown callouts for visibility:
+
+```markdown
+> [!QUESTION] [Category] Specific question or issue
+
+> [!WARNING] [Category] Issue description
+```
+
+Categories in brackets: `[Coherence]`, `[Assumption]`, `[Scope]`, `[Data]`
+
+Examples:
+
+```markdown
+## hypothesis
+
+We will implement progressive disclosure to reduce cognitive load.
+
+> [!QUESTION] [Coherence] The problem statement mentions "user confusion during onboarding" but this hypothesis addresses "cognitive load" generally. How does progressive disclosure specifically address the onboarding confusion?
+
+## in scope
+
+- User onboarding flow redesign
+- New tutorial system
+- Analytics dashboard for tracking engagement
+
+> [!WARNING] [Scope] "Analytics dashboard" appears disconnected from the hypothesis about progressive disclosure. Is this essential to testing the hypothesis, or scope creep?
+```
+
+## Persona
+
+Generic experienced product leader. Characteristics:
+- Critical but constructive
+- Questions assumptions without being dismissive
+- Focuses on strengthening the case, not tearing it down
+- Direct communication style
+- Expects justification, not just assertion
+
+## Completion Criteria
+
+A PRD can be marked "Ready for review" when:
+- Reasoning chain is complete and explicit
+- Key assumptions are stated
+- All in-scope items connect to goals
+- Claims have sources or are marked as hypotheses
+- No blocker or gap-level issues remain
+
+If issues remain after clarifications, verdict is "Needs work" with specific areas listed.
+
+## Technical Implementation
+
+### Skill Definition
+
+```yaml
+---
+name: prd-evaluation
+description: "Evaluate PRDs from a product leader's perspective. Use when the user wants to critique, review, or strengthen a PRD before stakeholder review. Triggers: evaluate this PRD, review my PRD, critique my PRD."
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+```
+
+### Required Tools
+
+- **Read**: Load PRD document
+- **AskUserQuestion**: Interactive clarification for gaps
+- **Write**: Save annotated PRD
+
+No codebase exploration tools (Glob, Grep) - evaluation is document-only.
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| File not found | Report error, ask for correct path |
+| Empty file | Ask user to provide PRD content |
+| No clear PRD content | Ask what document type this is |
+| User wants to stop early | Provide partial summary of findings so far |
+
+## Future Considerations (Out of Scope for v1)
+
+- Multiple persona options (skeptical exec, technical PM, user advocate)
+- Diff-aware iteration tracking
+- Integration with prd-writing skill (auto-suggest after creation)
+- Severity customization
+- Team-specific evaluation criteria

--- a/plugins/pm-workflow/.claude-plugin/plugin.json
+++ b/plugins/pm-workflow/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "pm-workflow",
-  "description": "Product management workflow skills for writing PRDs and product one-pagers",
-  "version": "1.0.0",
+  "description": "Product management workflow skills for writing and evaluating PRDs and product one-pagers",
+  "version": "1.1.0",
   "author": {
     "name": "Derek DeHart"
   },
-  "keywords": ["product", "prd", "requirements", "one-pager", "kickoff", "planning", "strategy"]
+  "keywords": ["product", "prd", "requirements", "one-pager", "kickoff", "planning", "strategy", "evaluation", "review", "critique"]
 }

--- a/plugins/pm-workflow/skills/prd-evaluation/SKILL.md
+++ b/plugins/pm-workflow/skills/prd-evaluation/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: prd-evaluation
+description: "Evaluate PRDs from a product leader's perspective. Use when the user wants to critique, review, or strengthen a PRD before stakeholder review. Triggers: evaluate this PRD, review my PRD, critique my PRD."
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+---
+
+# PRD Evaluation Skill
+
+Evaluate PRDs from an experienced product leader's perspective, surfacing gaps in reasoning, unstated assumptions, and disconnects between problem and solution.
+
+## Overview
+
+This skill operates as a critical reviewer, treating PRDs like thesis documents where every link in the chain of reasoning must be explicit and justified.
+
+**Core problem:** PRDs often contain "internalized context" - assumptions and connections that exist in the author's mind but never made it to the page. This creates gaps that confuse stakeholders and weaken the case for the initiative.
+
+**Activation:** This skill activates in two ways:
+- **Automatic:** Claude invokes it proactively when the user asks to evaluate, critique, or review a PRD
+- **Explicit:** Users can invoke directly with `/prd-evaluation @path/to/prd.md`
+
+## Workflow
+
+### 1. Accept Input
+
+Accept PRD via file reference only (`@path/to/prd.md`). Read the document directly.
+
+If no file provided, ask the user for the path.
+
+### 2. Initial Analysis
+
+Read the PRD and assess the reasoning chain:
+- Problem → Hypothesis: Does the solution address the stated problem?
+- Hypothesis → Scope: Does every in-scope item map to the approach?
+- Goals → Analytics: Can the metrics prove/disprove the hypothesis?
+
+### 3. Evaluate with Appropriate Response
+
+**For blockers (fundamental flaws):**
+- Stop immediately
+- Surface the core issue
+- Ask one clarifying question using `AskUserQuestion`
+- Wait for user response before continuing
+
+**For gaps (missing information):**
+- Stop and ask one clarifying question at a time
+- User provides answer
+- Continue evaluation
+
+**For weak reasoning (present but unconvincing):**
+- Annotate inline without stopping
+- Continue to next issue
+
+### 4. Annotate the Document
+
+Insert Markdown callouts at relevant locations:
+
+```markdown
+> [!QUESTION] [Category] Specific question about this section
+
+> [!WARNING] [Category] Issue that needs attention
+```
+
+Categories: `[Coherence]`, `[Assumption]`, `[Scope]`, `[Data]`
+
+### 5. Provide Summary
+
+After completing the evaluation, deliver a conversation summary:
+- **Verdict:** "Ready for review" / "Needs work" / "Fundamental gaps"
+- **Issue counts** by category
+- **Key areas** requiring attention
+
+### 6. Write Annotated PRD
+
+Save the annotated document back to the original file. Annotations are cleared on each run (fresh evaluation).
+
+## Evaluation Framework
+
+### Reasoning Chain Analysis
+
+The PRD should read like a thesis. Check each link:
+
+| Link | Question | Red Flags |
+|------|----------|-----------|
+| Problem → Hypothesis | Does the solution address the stated problem? | Solution solves different problem; problem too vague |
+| Hypothesis → Scope | Does every in-scope item map to the approach? | Scope items that don't serve hypothesis; missing items |
+| Goals → Analytics | Can metrics prove/disprove the hypothesis? | Vanity metrics; unmeasurable outcomes |
+
+### Issue Categories
+
+**Logical Coherence**
+- Missing steps in reasoning
+- Conclusions that don't follow from premises
+- Circular justifications ("we should do X because we need X")
+
+**Assumption Surfacing**
+- Unstated beliefs treated as facts
+- User behavior assumptions without validation
+- Technical or organizational dependencies not mentioned
+
+**Scope Creep Detection**
+- In-scope items with no clear connection to goals
+- "Nice to have" items mixed with core requirements
+- Scope larger than needed to test hypothesis
+
+**Data/Claim Validation**
+- Statistics without sources
+- Vague quantifiers ("most users", "significant improvement")
+- Claims presented as facts without evidence
+
+### Severity Levels
+
+| Severity | Behavior | Examples |
+|----------|----------|----------|
+| **Blocker** | Stop, address before continuing | Problem statement missing/incoherent; reasoning chain broken |
+| **Gap** | Stop, ask clarifying question | Key assumption unstated; metric unmeasurable; scope unexplained |
+| **Weak** | Annotate inline, continue | Claim without source; reasoning unconvincing; minor scope creep |
+
+### TBD Handling
+
+Sections explicitly marked as TBD or "to be researched" are acknowledged but not critiqued. Focus on content presented as complete.
+
+## Annotation Examples
+
+```markdown
+## hypothesis
+
+We will implement progressive disclosure to reduce cognitive load.
+
+> [!QUESTION] [Coherence] The problem statement mentions "user confusion during onboarding" but this hypothesis addresses "cognitive load" generally. How does progressive disclosure specifically address the onboarding confusion?
+
+## in scope
+
+- User onboarding flow redesign
+- New tutorial system
+- Analytics dashboard for tracking engagement
+
+> [!WARNING] [Scope] "Analytics dashboard" appears disconnected from the hypothesis about progressive disclosure. Is this essential to testing the hypothesis, or scope creep?
+
+## supporting data
+
+Users spend 40% more time on competitor apps.
+
+> [!WARNING] [Data] This statistic lacks a source. Where does the 40% figure come from?
+```
+
+## Persona
+
+Generic experienced product leader. Characteristics:
+- Critical but constructive
+- Questions assumptions without being dismissive
+- Focuses on strengthening the case, not tearing it down
+- Direct communication style
+- Expects justification, not just assertion
+
+## Completion Criteria
+
+A PRD can be marked "Ready for review" when:
+- Reasoning chain is complete and explicit
+- Key assumptions are stated
+- All in-scope items connect to goals
+- Claims have sources or are marked as hypotheses
+- No blocker or gap-level issues remain
+
+If issues remain after clarifications, verdict is "Needs work" with specific areas listed.
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| File not found | Report error, ask for correct path |
+| Empty file | Ask user to provide PRD content |
+| No clear PRD content | Ask what document type this is |
+| User wants to stop early | Provide partial summary of findings so far |
+
+## Key Constraints
+
+- **Must run in main conversation context** - `AskUserQuestion` is not available in forked/subagent contexts
+- **No `context: fork`** - evaluation requires interactive user engagement
+- **Document-only** - no codebase exploration; evaluate PRD as standalone document


### PR DESCRIPTION
## Summary

Adds a new skill that evaluates PRDs from a product leader's perspective, surfacing gaps in reasoning, unstated assumptions, and disconnects between problem and solution.

## Changes

- New skill: `plugins/pm-workflow/skills/prd-evaluation/SKILL.md` - Comprehensive PRD evaluation tool with multi-stage analysis
- Spec: `docs/specs/prd-evaluation-skill.md` - Detailed specification and design documentation
- Version bumps: pm-workflow 1.0.0 → 1.1.0 across plugin.json and marketplace.json
- README updates: Added skill to component table and usage documentation

## Test Plan

- [x] Skill metadata (YAML frontmatter) is valid
- [x] Markdown formatting is correct
- [x] Instructions are clear and actionable
- [x] Version numbers match in plugin.json and marketplace.json
- [ ] Verify skill works as expected during installation testing

🤖 Generated with Claude Code