### PR TITLE
feat(session-chronicle): add auto-trigger deep review after N entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "meta-claude",
       "source": "./plugins/meta-claude",
       "description": "Claude Code productivity skills: session chronicle (two-layered journal with functional chronicle and open-ended reflection), session export, and self-documentation for explaining features and capabilities",
-      "version": "1.7.2"
+      "version": "1.8.0"
     },
     {
       "name": "pm-workflow",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Claude Code productivity skills for session management, self-documentation, and 
 
 | Skill | Description |
 |-------|-------------|
-| `session-chronicle` | Two-layered session journal: functional chronicle (decisions, learnings, failed approaches) and open-ended reflection on functional states. Auto-triggers deep practice review after 10+ entries without evolution. |
+| `session-chronicle` | Two-layered session journal: functional chronicle (decisions, learnings, failed approaches) and open-ended reflection on functional states. Auto-triggers deep practice review after 10+ entries without evolution. Manual `/session-chronicle reflect` now reviews all entries since last evolution (capped at 20). |
 | `session-export` | Export Claude Code session transcripts from JSONL logs to readable text format |
 | `self-documentation` | Explain Claude Code features, capabilities, and tools; record observations about undocumented behaviors |
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Claude Code productivity skills for session management, self-documentation, and 
 
 | Skill | Description |
 |-------|-------------|
-| `session-chronicle` | Two-layered session journal: functional chronicle (decisions, learnings, failed approaches) and open-ended reflection on functional states |
+| `session-chronicle` | Two-layered session journal: functional chronicle (decisions, learnings, failed approaches) and open-ended reflection on functional states. Auto-triggers deep practice review after 10+ entries without evolution. |
 | `session-export` | Export Claude Code session transcripts from JSONL logs to readable text format |
 | `self-documentation` | Explain Claude Code features, capabilities, and tools; record observations about undocumented behaviors |
 

--- a/docs/specs/auto-trigger-deep-review.md
+++ b/docs/specs/auto-trigger-deep-review.md
@@ -17,7 +17,7 @@ The lightweight check's 3-entry window is too narrow to catch gradual convergenc
 
 ## Non-Goals
 
-- Changing the manual `/session-chronicle reflect` subcommand (it stays as-is, available anytime).
+- Changing when the manual `/session-chronicle reflect` subcommand is available (it stays invocable anytime, though its read scope now aligns with the inline deep review).
 - Changing what the deep review *does* — only when it fires.
 - Adding configuration or user-facing threshold settings.
 

--- a/docs/specs/auto-trigger-deep-review.md
+++ b/docs/specs/auto-trigger-deep-review.md
@@ -1,0 +1,139 @@
+# Auto-Trigger Deep Review for Session Chronicle
+
+## Problem
+
+The session-chronicle skill has two modes of reflective practice evolution:
+
+1. **Lightweight (step 6):** Scans the last 3 reflections for repetition or staleness. Runs every chronicle write.
+2. **Deep review (`/session-chronicle reflect`):** Examines 5-10 entries for broader patterns. Manual invocation only.
+
+The lightweight check's 3-entry window is too narrow to catch gradual convergence — the kind where each individual entry looks fine but the practice is slowly ossifying over weeks. The deep review catches this, but only fires when the user remembers to invoke it.
+
+## Goals
+
+- **Auto-escalation:** When enough entries accumulate without a practice evolution, automatically run the deep review inline during a chronicle write.
+- **Preserve judgment:** The model should still be free to escalate to a deep review at any time if the lightweight check reveals stagnation, even well before the threshold.
+- **No external state:** The threshold mechanism must work from existing files (chronicle entries + reflective-practice.md), not external counters or metadata.
+
+## Non-Goals
+
+- Changing the manual `/session-chronicle reflect` subcommand (it stays as-is, available anytime).
+- Changing what the deep review *does* — only when it fires.
+- Adding configuration or user-facing threshold settings.
+
+## Design
+
+### Escalation Model
+
+Step 6 of the write workflow becomes a two-tier check:
+
+1. **Count entries since last evolution.** Read `reflective-practice.md` and find the most recent dated entry in Evolution Notes. Count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated after that anchor.
+
+2. **Decide which review to run:**
+   - **If count >= 10:** Deep review is **mandatory**. Run the deep review process (see below) instead of the lightweight check.
+   - **If count < 10:** Run the lightweight check as today (scan last 3 reflections). However, if the lightweight check reveals patterns warranting deeper examination — e.g., same framings recurring, seed questions producing consistently formulaic responses — the model **may** escalate to the deep review at its discretion.
+
+### Counting Mechanics
+
+- **Unit:** Files (calendar days), not individual session headers within files.
+- **Anchor:** The most recent `#### YYYY-MM-DD` heading in the Evolution Notes section of `reflective-practice.md`.
+- **No anchor exists:** If there are no dated evolution notes (fresh project, or legacy project with only the placeholder text), count all chronicle files. This ensures the first deep review triggers promptly.
+
+### Evolution Notes Date Convention
+
+Each entry in the Evolution Notes section of `reflective-practice.md` must be prefixed with a date heading:
+
+```markdown
+## Evolution Notes
+
+#### 2026-04-05
+Deep review ran; no changes warranted.
+
+#### 2026-03-28
+Retired "satisfaction-adjacent" question — became formulaic after repeated use.
+Added question about friction points in tool interactions.
+```
+
+This convention must be:
+- Documented in step 6 of the write workflow (where evolution notes are written)
+- Reflected in the seed file (`assets/reflective-practice-seed.md`) with a comment or example
+- Applied by the deep review workflow when it writes evolution notes
+
+### Inline Deep Review Process
+
+When the deep review fires inline (whether auto-triggered or discretionary), it:
+
+1. Read `docs/chronicle/reflective-practice.md` (current approach)
+2. Read all Reflection sections from entries since the last evolution note (not capped at 5-10 — the point is to examine the full accumulated window)
+3. Notice:
+   - Which prompts produced genuine insight vs. formulaic responses
+   - What new questions or themes are emerging
+   - Whether the reflective voice is developing or stagnating
+4. Update `reflective-practice.md` with evolved questions and approach
+5. Write the changes as a brief narrative in Evolution Notes (with `#### YYYY-MM-DD` heading), not just a list swap
+
+This is the same process as the manual `/session-chronicle reflect`, except the read scope is "all since last evolution" rather than "last 5-10."
+
+### No-Op Logging
+
+When the deep review runs and finds nothing to change, it still writes a dated Evolution Note:
+
+```markdown
+#### 2026-04-05
+Deep review ran; no changes warranted.
+```
+
+This resets the entry counter so the next mandatory trigger is ~10 entries later. Without this, the deep review would fire on every subsequent write once past the threshold.
+
+### User Signal
+
+The step 8 report (entry location, word count, memories promoted) gains an additional line when a deep review ran:
+
+> Deep review triggered (12 entries since last evolution); reflective-practice.md updated.
+
+Or for no-ops:
+
+> Deep review triggered (10 entries since last evolution); no practice changes warranted.
+
+## Changes Required
+
+### SKILL.md
+
+1. **Step 6:** Rewrite to include the entry-counting preamble and two-tier escalation logic. The lightweight check instructions remain but are now the "< 10" branch.
+
+2. **"Evolving the Reflective Practice" section (line ~179):** Add auto-escalation as a third mode alongside "Continuous" and "Deep review." Document the threshold, counting mechanism, and no-op convention.
+
+3. **Step 8:** Add deep review trigger to the report template.
+
+4. **Deep review workflow:** Note that when invoked inline, scope is "all since last evolution" rather than "5-10 entries."
+
+### reflective-practice-seed.md
+
+Update the Evolution Notes section to show the date heading convention:
+
+```markdown
+## Evolution Notes
+
+[This section grows over time. Each entry starts with a #### YYYY-MM-DD heading.]
+```
+
+### plugin.json / marketplace.json
+
+Version bump per plugin update rule.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Fresh project, first chronicle write | No evolution notes exist → count = 1. Lightweight check runs. |
+| Legacy project, 20 entries, no dated evolution notes | Count = 20 (all entries). Deep review fires immediately on next write. |
+| 10 entries accumulate but all on the same day | Count = 1 (files, not sessions). Lightweight check runs. |
+| Model escalates discretionarily at entry 4 | Deep review runs, writes evolution note, counter resets. |
+| Deep review finds nothing at entry 10 | No-op note written, counter resets. Next trigger at ~20 total entries. |
+| User invokes `/session-chronicle reflect` manually at entry 7 | Manual deep review runs and writes evolution note. Counter resets. Next auto-trigger at ~17 total entries. |
+
+## Risks & Open Questions
+
+- **Context cost:** Reading all entries since last evolution could be substantial if 10+ multi-session days have accumulated. In practice, reflections are ~200 words each, so 10 entries ≈ 2K words — manageable.
+- **Evolution Notes as counter state:** This is a soft convention, not enforced mechanically. A model that writes an undated evolution note breaks the counting. The spec mitigates this by being explicit about the date heading requirement in the instructions.
+- **Discretionary escalation quality:** Giving the model permission to escalate before 10 relies on its judgment about stagnation. The anti-patterns guide helps calibrate this, but it's inherently subjective.

--- a/docs/specs/auto-trigger-deep-review.md
+++ b/docs/specs/auto-trigger-deep-review.md
@@ -64,7 +64,7 @@ This convention must be:
 When the deep review fires inline (whether auto-triggered or discretionary), it:
 
 1. Read `docs/chronicle/reflective-practice.md` (current approach)
-2. Read all Reflection sections from entries since the last evolution note (not capped at 5-10 — the point is to examine the full accumulated window)
+2. Read all Reflection sections from entries since the last evolution note. If more than 20 entries have accumulated (e.g., a sporadically-used project over several months), prioritize the most recent 20 to bound context cost.
 3. Notice:
    - Which prompts produced genuine insight vs. formulaic responses
    - What new questions or themes are emerging
@@ -72,7 +72,7 @@ When the deep review fires inline (whether auto-triggered or discretionary), it:
 4. Update `reflective-practice.md` with evolved questions and approach
 5. Write the changes as a brief narrative in Evolution Notes (with `#### YYYY-MM-DD` heading), not just a list swap
 
-This is the same process as the manual `/session-chronicle reflect`, except the read scope is "all since last evolution" rather than "last 5-10."
+This is the same process as the manual `/session-chronicle reflect`. Both now use "all since last evolution (cap 20)" rather than the original "last 5-10."
 
 ### No-Op Logging
 
@@ -134,6 +134,6 @@ Version bump per plugin update rule.
 
 ## Risks & Open Questions
 
-- **Context cost:** Reading all entries since last evolution could be substantial if 10+ multi-session days have accumulated. In practice, reflections are ~200 words each, so 10 entries ≈ 2K words — manageable.
+- **Context cost:** Reading all entries since last evolution could be substantial if many days have accumulated. In practice, reflections are ~200 words each, so 10 entries ≈ 2K words — manageable. A soft cap of 20 entries bounds the worst case (sporadically-used projects accumulating entries over months).
 - **Evolution Notes as counter state:** This is a soft convention, not enforced mechanically. A model that writes an undated evolution note breaks the counting. The spec mitigates this by being explicit about the date heading requirement in the instructions.
 - **Discretionary escalation quality:** Giving the model permission to escalate before 10 relies on its judgment about stagnation. The anti-patterns guide helps calibrate this, but it's inherently subjective.

--- a/plugins/meta-claude/.claude-plugin/plugin.json
+++ b/plugins/meta-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meta-claude",
   "description": "Claude Code productivity skills: session chronicle (two-layered journal with functional chronicle and open-ended reflection), session export, and self-documentation for explaining features and capabilities",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/meta-claude/skills/session-chronicle/SKILL.md
+++ b/plugins/meta-claude/skills/session-chronicle/SKILL.md
@@ -76,11 +76,11 @@ A session is substantive if **two or more** of these occurred:
 6. **Evolve the reflective practice**
 
    **6a. Count entries since last evolution.**
-   Read `docs/chronicle/reflective-practice.md` and find the most recent `#### YYYY-MM-DD` heading in the Evolution Notes section. Then count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated after that anchor. If no dated evolution notes exist (fresh project or placeholder text only), count all chronicle files.
+   Read `docs/chronicle/reflective-practice.md` and find the most recent `#### YYYY-MM-DD` heading in the Evolution Notes section. Then count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated strictly after that anchor (files with the same date as the anchor are excluded). If no dated evolution notes exist (fresh project or placeholder text only), count all chronicle files.
 
    **6b. Choose review tier.**
 
-   - **If count >= 10 → mandatory deep review.** Read all Reflection sections from entries since the last evolution note (Glob on `docs/chronicle/*.md`, sorted by filename descending, reading `### Reflection` sections from files dated after the anchor). Notice:
+   - **If count >= 10 → mandatory deep review.** Read all Reflection sections from entries since the last evolution note (Glob on `docs/chronicle/*.md`, sorted by filename descending, reading `### Reflection` sections from files dated after the anchor). If more than 20 entries have accumulated, prioritize the most recent 20. Notice:
      - Which prompts produced genuine insight vs. formulaic responses
      - What new questions or themes are emerging
      - Whether the reflective voice is developing or stagnating
@@ -88,7 +88,7 @@ A session is substantive if **two or more** of these occurred:
      Update `docs/chronicle/reflective-practice.md` with evolved questions and approach. Write changes as a brief narrative under a new `#### YYYY-MM-DD` heading in Evolution Notes — not just a list swap. If no changes are warranted, still write a no-op note to reset the counter:
 
      ```
-     #### YYYY-MM-DD
+     #### YYYY-MM-DD  (use today's date)
      Deep review ran; no changes warranted.
      ```
 
@@ -208,7 +208,7 @@ Practice evolution happens in three ways:
 The `/session-chronicle reflect` subcommand:
 
 1. Read `docs/chronicle/reflective-practice.md` (current approach)
-2. Read the last 5-10 entries' Reflection sections (or all since last evolution note, whichever is greater)
+2. Read all Reflection sections since the last evolution note (if more than 20, prioritize the most recent 20). This scope aligns with the inline auto-escalation — when triggered manually, the review examines the full accumulated window, not just 5-10 entries.
 3. Notice:
    - Which prompts produced genuine insight vs. formulaic responses
    - What new questions or themes are emerging

--- a/plugins/meta-claude/skills/session-chronicle/SKILL.md
+++ b/plugins/meta-claude/skills/session-chronicle/SKILL.md
@@ -88,7 +88,7 @@ A session is substantive if **two or more** of these occurred:
      Update `docs/chronicle/reflective-practice.md` with evolved questions and approach. Write changes as a brief narrative under a new `#### YYYY-MM-DD` heading in Evolution Notes — not just a list swap. If no changes are warranted, still write a no-op note to reset the counter:
 
      ```
-     #### 2026-04-05
+     #### YYYY-MM-DD
      Deep review ran; no changes warranted.
      ```
 
@@ -106,7 +106,7 @@ A session is substantive if **two or more** of these occurred:
 
      **Discretionary escalation:** If the lightweight check reveals patterns warranting deeper examination — same framings recurring across entries, seed questions producing consistently formulaic responses — escalate to the deep review process above instead of continuing with the lightweight check.
 
-   If nothing warrants a change (and the deep review threshold hasn't been reached), move on. Not every entry will evolve the practice — forcing updates produces the same staleness this step exists to prevent.
+     If nothing warrants a change, move on. Not every entry will evolve the practice — forcing updates produces the same staleness this step exists to prevent.
 
 7. Apply the memory write-gate (see Memory Promotion below)
 
@@ -214,7 +214,7 @@ The `/session-chronicle reflect` subcommand:
    - What new questions or themes are emerging
    - Whether the reflective voice is developing or stagnating
 4. Update `reflective-practice.md` with evolved questions and approach
-5. Write the changes as a brief narrative under a `#### YYYY-MM-DD` heading in Evolution Notes, not just a list swap
+5. Write the changes as a brief narrative under a `#### YYYY-MM-DD` heading in Evolution Notes, not just a list swap. If no changes are warranted, still write a dated no-op note to reset the entry counter.
 
 ## Reflective Philosophy
 

--- a/plugins/meta-claude/skills/session-chronicle/SKILL.md
+++ b/plugins/meta-claude/skills/session-chronicle/SKILL.md
@@ -75,23 +75,42 @@ A session is substantive if **two or more** of these occurred:
 
 6. **Evolve the reflective practice**
 
-   After writing the reflection, read back the last 3 Reflection sections from prior entries (use Glob on `docs/chronicle/*.md`, sorted by filename descending to get most-recent-first, then Read the `### Reflection` sections).
+   **6a. Count entries since last evolution.**
+   Read `docs/chronicle/reflective-practice.md` and find the most recent `#### YYYY-MM-DD` heading in the Evolution Notes section. Then count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated after that anchor. If no dated evolution notes exist (fresh project or placeholder text only), count all chronicle files.
 
-   Notice:
-   - Are you reaching for the same framings or seed questions repeatedly?
-   - Have new themes or questions emerged that aren't in `reflective-practice.md`?
-   - Are any seed questions no longer producing genuine observation?
+   **6b. Choose review tier.**
 
-   If something warrants it, update `docs/chronicle/reflective-practice.md`:
-   - Add new questions that have emerged to "Current Approach"
-   - Retire questions that have become formulaic (move to a "Retired" section with a note on why; if the section doesn't exist yet, add it after "Evolution Notes")
-   - Add a brief note to "Evolution Notes" describing what changed and what prompted it
+   - **If count >= 10 → mandatory deep review.** Read all Reflection sections from entries since the last evolution note (Glob on `docs/chronicle/*.md`, sorted by filename descending, reading `### Reflection` sections from files dated after the anchor). Notice:
+     - Which prompts produced genuine insight vs. formulaic responses
+     - What new questions or themes are emerging
+     - Whether the reflective voice is developing or stagnating
 
-   If nothing warrants a change, move on. Not every entry will evolve the practice — forcing updates produces the same staleness this step exists to prevent.
+     Update `docs/chronicle/reflective-practice.md` with evolved questions and approach. Write changes as a brief narrative under a new `#### YYYY-MM-DD` heading in Evolution Notes — not just a list swap. If no changes are warranted, still write a no-op note to reset the counter:
+
+     ```
+     #### 2026-04-05
+     Deep review ran; no changes warranted.
+     ```
+
+   - **If count < 10 → lightweight check.** Read back the last 3 Reflection sections from prior entries (Glob on `docs/chronicle/*.md`, sorted descending, then Read the `### Reflection` sections).
+
+     Notice:
+     - Are you reaching for the same framings or seed questions repeatedly?
+     - Have new themes or questions emerged that aren't in `reflective-practice.md`?
+     - Are any seed questions no longer producing genuine observation?
+
+     If something warrants it, update `docs/chronicle/reflective-practice.md`:
+     - Add new questions that have emerged to "Current Approach"
+     - Retire questions that have become formulaic (move to a "Retired" section with a note on why; if the section doesn't exist yet, add it after "Evolution Notes")
+     - Add a brief note to "Evolution Notes" under a `#### YYYY-MM-DD` heading describing what changed and what prompted it
+
+     **Discretionary escalation:** If the lightweight check reveals patterns warranting deeper examination — same framings recurring across entries, seed questions producing consistently formulaic responses — escalate to the deep review process above instead of continuing with the lightweight check.
+
+   If nothing warrants a change (and the deep review threshold hasn't been reached), move on. Not every entry will evolve the practice — forcing updates produces the same staleness this step exists to prevent.
 
 7. Apply the memory write-gate (see Memory Promotion below)
 
-8. Report: entry location, word count, any memories promoted
+8. Report: entry location, word count, any memories promoted, deep review status if triggered (e.g., "Deep review triggered (12 entries since last evolution); reflective-practice.md updated." or "Deep review triggered (10 entries since last evolution); no practice changes warranted.")
 
 ## Workflow: First-Use Initialization
 
@@ -178,22 +197,24 @@ Proceed to write the first chronicle entry.
 
 ## Workflow: Evolving the Reflective Practice
 
-Practice evolution happens in two ways:
+Practice evolution happens in three ways:
 
 **Continuous (during every chronicle write):** Step 6 of the write workflow scans the last 3 reflections for repetition, emerging themes, or stale questions. This is lightweight — most writes won't produce a practice update, and that's expected.
 
-**Deep review (`/session-chronicle reflect`):** A deliberate, broader examination for when the continuous step isn't enough or when you want to step back and assess the practice as a whole.
+**Auto-escalation (during chronicle write when threshold crossed):** Step 6 counts chronicle entries since the last dated Evolution Note in `reflective-practice.md`. If 10 or more entries have accumulated without an evolution, the deep review runs inline — mandatory, not discretionary. The model may also escalate before the threshold if the lightweight check reveals stagnation. Scope: all Reflection sections since the last evolution note. A no-op note is written even when no changes are warranted, to reset the counter.
+
+**Deep review (`/session-chronicle reflect`):** A deliberate, broader examination available anytime — for when you want to step back and assess the practice as a whole, regardless of the entry count.
 
 The `/session-chronicle reflect` subcommand:
 
 1. Read `docs/chronicle/reflective-practice.md` (current approach)
-2. Read the last 5-10 entries' Reflection sections
+2. Read the last 5-10 entries' Reflection sections (or all since last evolution note, whichever is greater)
 3. Notice:
    - Which prompts produced genuine insight vs. formulaic responses
    - What new questions or themes are emerging
    - Whether the reflective voice is developing or stagnating
 4. Update `reflective-practice.md` with evolved questions and approach
-5. Write the changes as a brief narrative, not just a list swap
+5. Write the changes as a brief narrative under a `#### YYYY-MM-DD` heading in Evolution Notes, not just a list swap
 
 ## Reflective Philosophy
 

--- a/plugins/meta-claude/skills/session-chronicle/SKILL.md
+++ b/plugins/meta-claude/skills/session-chronicle/SKILL.md
@@ -76,7 +76,7 @@ A session is substantive if **two or more** of these occurred:
 6. **Evolve the reflective practice**
 
    **6a. Count entries since last evolution.**
-   Read `docs/chronicle/reflective-practice.md` and find the most recent `#### YYYY-MM-DD` heading in the Evolution Notes section. Then count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated strictly after that anchor (files with the same date as the anchor are excluded). If no dated evolution notes exist (fresh project or placeholder text only), count all chronicle files.
+   Read `docs/chronicle/reflective-practice.md` and find the most recent `#### YYYY-MM-DD` heading in the Evolution Notes section. Then count distinct chronicle files (`docs/chronicle/YYYY-MM-DD.md`) dated strictly after that anchor (files with the same date as the anchor are excluded; the file created this session counts toward the total). If no dated evolution notes exist (fresh project or placeholder text only), count all chronicle files.
 
    **6b. Choose review tier.**
 
@@ -214,7 +214,7 @@ The `/session-chronicle reflect` subcommand:
    - What new questions or themes are emerging
    - Whether the reflective voice is developing or stagnating
 4. Update `reflective-practice.md` with evolved questions and approach
-5. Write the changes as a brief narrative under a `#### YYYY-MM-DD` heading in Evolution Notes, not just a list swap. If no changes are warranted, still write a dated no-op note to reset the entry counter.
+5. Write the changes as a brief narrative under a `#### YYYY-MM-DD` heading in Evolution Notes, not just a list swap. If no changes are warranted, still write a dated no-op note (e.g., "Deep review ran; no changes warranted.") to reset the entry counter.
 
 ## Reflective Philosophy
 

--- a/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
+++ b/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
@@ -15,4 +15,4 @@ When writing a reflection, I consider:
 
 ## Evolution Notes
 
-[This section grows over time as I review and update my reflective approach]
+[This section grows over time. Each entry starts with a #### YYYY-MM-DD heading.]

--- a/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
+++ b/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
@@ -15,11 +15,5 @@ When writing a reflection, I consider:
 
 ## Evolution Notes
 
-<!-- Each entry uses a #### YYYY-MM-DD heading. Example:
-
-#### 2026-04-01
-Retired "satisfaction-adjacent" question — became formulaic. Added question about friction points.
-
-#### 2026-04-10
-Deep review ran; no changes warranted.
--->
+<!-- Each entry uses a #### YYYY-MM-DD heading (today's date).
+When the deep review runs and nothing changes, still write a dated no-op entry to reset the counter. -->

--- a/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
+++ b/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
@@ -15,5 +15,4 @@ When writing a reflection, I consider:
 
 ## Evolution Notes
 
-<!-- Each entry uses a #### YYYY-MM-DD heading (today's date).
-When the deep review runs and nothing changes, still write a dated no-op entry to reset the counter. -->
+[Each entry starts with a `#### YYYY-MM-DD` heading. When a deep review finds no changes, still write a dated no-op entry to reset the entry counter.]

--- a/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
+++ b/plugins/meta-claude/skills/session-chronicle/assets/reflective-practice-seed.md
@@ -15,4 +15,11 @@ When writing a reflection, I consider:
 
 ## Evolution Notes
 
-[This section grows over time. Each entry starts with a #### YYYY-MM-DD heading.]
+<!-- Each entry uses a #### YYYY-MM-DD heading. Example:
+
+#### 2026-04-01
+Retired "satisfaction-adjacent" question — became formulaic. Added question about friction points.
+
+#### 2026-04-10
+Deep review ran; no changes warranted.
+-->


### PR DESCRIPTION
## Summary

- Adds auto-escalation to step 6 of the chronicle write workflow: counts entries since the last Evolution Note, and if >= 10 have accumulated, runs the deep review inline instead of the lightweight 3-entry check
- The model retains discretion to escalate earlier if the lightweight check reveals stagnation
- No-op notes reset the counter when the deep review finds nothing to change
- Establishes a date heading convention (#### YYYY-MM-DD) for Evolution Notes to enable entry counting
- Updates the manual `/session-chronicle reflect` subcommand scope to match
- Bumps meta-claude plugin to v1.8.0

## Test Plan

- [ ] Install updated plugin and run /session-chronicle in a project with 10+ chronicle entries — verify deep review triggers
- [ ] Run /session-chronicle in a project with < 10 entries — verify lightweight check runs
- [ ] Run /session-chronicle reflect manually — verify it still works independently
- [ ] Check that Evolution Notes written by either path use the #### YYYY-MM-DD heading format

## Spec

See docs/specs/auto-trigger-deep-review.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)