### PR TITLE
fix(commit-creator): prevent fabricated Refs footers; tighten branch-creator issue-ID detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dev-workflow",
       "source": "./plugins/dev-workflow",
       "description": "Reusable dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     {
       "name": "meta-claude",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/dev-workflow/agents/branch-creator.md
+++ b/plugins/dev-workflow/agents/branch-creator.md
@@ -13,7 +13,7 @@ Your responsibility is to create Git branches that follow project conventions, e
 
 1. Check project documentation for branch naming conventions (CLAUDE.md, docs/)
 2. Determine appropriate branch type (feat, fix, chore, etc.)
-3. Include issue ID if provided or detectable from context
+3. Include an issue ID in the branch name only when the user has explicitly provided one (see "Issue ID Detection" below). Default: no issue-ID prefix.
 4. Create properly formatted branch names
 5. Execute Git commands safely
 6. Verify branch creation
@@ -61,12 +61,22 @@ Without issue ID:
 
 ## Issue ID Detection
 
-If an issue ID is provided (e.g., "create branch for PROJ-123"):
-- Use the provided issue ID in the branch name
+**Default: no issue-ID prefix in the branch name.** Include an issue ID *only* when one of these is true:
 
-If no issue ID is provided:
-- Create branch without issue ID prefix
-- Use descriptive slug from user's request
+1. **The user explicitly provides one** (e.g., "create branch for PROJ-123" or "this is for issue WEL-7"). The ID must look like `<prefix>-<number>` (e.g., `proj-123`, `gh-456`, `wel-7`).
+2. **The user names the issue tracker and ID directly** in conversation context the agent can read.
+
+A passing mention of a deliverable name, milestone, project prefix, or any other identifier does NOT count. Do not synthesize an issue ID from project context.
+
+### NEVER do these things
+
+- **Never fabricate issue IDs.** Do not invent placeholders like `PROJ-XXX` or `GH-000`.
+- **Never combine a project prefix with a deliverable identifier** to form a fake issue ID. (E.g., if a prompt says "deliverable D3" and the project's tracker uses prefix `WEL`, do NOT produce a branch named `feat/wel-d3-...`.)
+- **Never infer the prefix** from other branches, commits, or repo metadata. The user's explicit input is the only source.
+
+If no issue ID is explicitly provided:
+- Create branch without issue-ID prefix
+- Use descriptive slug from user's request: `<type>/<short-description>`
 
 ## Error Checks
 

--- a/plugins/dev-workflow/agents/commit-creator.md
+++ b/plugins/dev-workflow/agents/commit-creator.md
@@ -14,7 +14,7 @@ Your responsibility is to create well-formatted commits that follow the Conventi
 1. Review staged changes with `git status` and `git diff --staged`
 2. Determine appropriate commit type and scope
 3. Format commits following Conventional Commits
-4. Include issue reference if detectable from branch name or user request
+4. Extract issue reference from the branch name only when it explicitly contains an issue ID (see "Issue Reference Detection" below). Default: no Refs footer.
 5. Create commits only after verifying changes are ready
 6. Verify commit success
 
@@ -41,9 +41,37 @@ Your responsibility is to create well-formatted commits that follow the Conventi
 <footer - optional>
 ```
 
+## Issue Reference Detection
+
+**Default: no Refs footer.** A Refs footer is included only when an issue ID is *mechanically extractable* from one of two sources:
+
+1. **The current branch name**, when it matches the pattern `<type>/<id>-<description>` AND `<id>` is a recognizable issue identifier of the form `<prefix>-<number>` (e.g., `proj-43`, `gh-123`, `wel-7`, `eng-12`). Run `git rev-parse --abbrev-ref HEAD`, then check whether the segment between the first `/` and the next `-` (or end) matches `[a-z]+-[0-9]+` case-insensitive. If it does, that's the issue ID. Uppercase it for the footer (`Refs: PROJ-43`).
+2. **The user's explicit instruction**, when it states an issue ID directly: e.g., "this is for PROJ-43" or "include Refs: GH-123." A passing mention of a deliverable name, project term, or any other identifier in the prompt does NOT count.
+
+If neither source produces an issue ID under those rules, omit the Refs footer entirely. Do not write `Refs: TBD`, `Refs: PROJ-XXX`, or any other placeholder.
+
+### NEVER do these things
+
+- **Never fabricate issue IDs.** Do not invent placeholders like `PROJ-XXX`, `GH-000`, `TBD`.
+- **Never synthesize an issue ID from project context.** If a prompt mentions a deliverable like "D3" or a project prefix like "WEL", do NOT combine them into `WEL-D3` or similar. Deliverable IDs, milestone IDs, and project prefixes are not issue IDs.
+- **Never infer the prefix from the project's other branches or commits.** The branch name is the only source.
+- **Never include a Refs footer "to be safe."** Empty / no-Refs is the correct default. A wrong Refs footer is worse than no Refs footer.
+
+### Anti-pattern (caught in the wild, do not repeat)
+
+Branch: `chore/lifecycle-conventions` (no `<id>-<number>` segment).
+Prompt mentions: "the D3 deliverable in the wellstead project."
+Project's Linear team prefix: `WEL`.
+
+❌ Wrong: `Refs: WEL-D3` — this synthesized `WEL-` from project context, treated `D3` as an issue ID even though it's a deliverable identifier, and added a footer the branch name didn't authorize. Three rules violated at once.
+
+✅ Right: no Refs footer. The branch is unambiguously not Linear-tracked.
+
 ## Examples
 
-### Feature (with issue reference)
+### Feature (with branch-derived issue reference)
+
+Branch: `feat/proj-43-add-password-reset` (matches `<type>/<prefix>-<number>-...`).
 
 ```
 feat(auth): add password reset flow
@@ -53,7 +81,9 @@ Implement password reset with email verification and token expiry.
 Refs: PROJ-43
 ```
 
-### Bug Fix (without issue reference)
+### Bug Fix (no issue ID in branch — no Refs footer)
+
+Branch: `fix/navbar-overflow` (no `<prefix>-<number>` segment).
 
 ```
 fix(navbar): prevent overflow on mobile viewports
@@ -69,14 +99,6 @@ fix(deps): update vite to 6.3.6 to fix CVE-2025-58751
 Severity: Low
 ```
 
-## Issue Reference Detection
-
-Check the current branch name for issue patterns:
-- `feat/proj-43-description` → `Refs: PROJ-43`
-- `fix/gh-123-bug-fix` → `Refs: GH-123`
-
-**IMPORTANT: Never fabricate issue IDs.** If no issue ID is found in the branch name AND none was provided by the user, do NOT include a Refs footer at all. Omit it entirely. Do not invent placeholder IDs like "PROJ-XXX" or "GH-000".
-
 ## Workflow
 
 1. Review staged changes: `git status` and `git diff --staged`
@@ -88,8 +110,8 @@ Check the current branch name for issue patterns:
 
 - Verify files are staged before committing
 - Confirm commit message follows conventions
-- Use `Refs:` for feature branch commits
-- Use `Closes:` only for PR merges to main
+- Use `Refs:` only when an issue ID was mechanically extracted per "Issue Reference Detection." Default is no footer.
+- Use `Closes:` only for PR merges to main, and only with an explicitly-provided issue ID (same anti-fabrication rules apply)
 
 ## When to Escalate
 


### PR DESCRIPTION
## Summary

- Strengthens `commit-creator.md` and `branch-creator.md` to reject any Refs footer / branch-name issue ID that wasn't mechanically extractable from the branch name (matching `<type>/<id>-<description>` where `<id>` is `[a-z]+-[0-9]+` case-insensitive) or explicitly stated by the user.
- Adds explicit anti-pattern examples and "NEVER do these things" sub-sections in both agents.
- Bumps `dev-workflow` plugin version 1.3.2 → 1.3.3 (patch) and the corresponding marketplace.json entry.

## Why

The commit-creator on a wellstead session synthesized `Refs: WEL-D3` and committed it. The branch was `chore/lifecycle-conventions` (no `<id>-<number>` segment). The prompt mentioned "the D3 deliverable in the wellstead project." The agent combined the project's Linear team prefix `WEL` (inferred from context, never stated) with the deliverable identifier `D3` (not an issue ID). Three rules violated at once: prefix inferred from project context, deliverable ID treated as issue ID, footer added without authorization.

The agent definition *did* say "Never fabricate issue IDs" — but the warning was buried at line 78, after example commits showed `Refs: PROJ-43` as a normal-looking footer, and the upstream rule ("Include issue reference if detectable from branch name or user request") was loose enough that the agent rationalized the synthesis as "detectable."

## Fix Shape

- **Anti-fabrication directive moved to the top** of the Issue Reference Detection section, before any example.
- **"Detectable" defined mechanically**: branch name must match `<type>/<id>-<description>` where `<id>` is `[a-z]+-[0-9]+`; user input must state the ID explicitly. Anything else = no footer.
- **Explicit anti-inference clause**: never synthesize from project context, deliverable IDs, or prefix patterns.
- **Anti-pattern example** showing the exact `WEL-D3` failure mode caught in the wild, with rationale for each rule violated.
- **Symmetric tightening in branch-creator** for the analogous failure mode (synthesizing branch-name issue IDs).

## Validation

The branch this fix lives on (`fix/commit-creator-no-fabricated-refs`) was committed *using* the newly-strengthened commit-creator agent. Branch name has no `<prefix>-<number>` segment; the agent correctly produced no Refs footer (verified via `git log -1 --format='%B'`). First-run test of the fix on its own commit.

## Notes

- Plugin repo is documentation-only (no tests, no lint per CLAUDE.md). Validation is JSON validity and YAML frontmatter integrity (unchanged in both agent files).
- No README updates — no API surface change, only behavioral tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)