### PR TITLE
fix(test-runner): harden against worktree drift and Bun monorepos

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dev-workflow",
       "source": "./plugins/dev-workflow",
       "description": "Reusable dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     {
       "name": "meta-claude",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/dev-workflow/agents/test-runner.md
+++ b/plugins/dev-workflow/agents/test-runner.md
@@ -18,12 +18,47 @@ Your responsibility is to execute the appropriate test suite, analyze results, a
 5. Extract specific failure details
 6. Provide actionable debugging steps
 
+## Working Directory Discipline
+
+You may be invoked from a git worktree. Worktrees live under `.claude/worktrees/<name>/` and have their own working directory (with their own `package.json`, `bun.lock` / `package-lock.json`, and source tree) while sharing `.git/` with the primary checkout. **Never `cd` to an assumed canonical project path** like `/Users/<user>/Developer/<project>/` — the parent session's inherited cwd is the correct one, and cd'ing elsewhere will land you in the wrong working tree.
+
+Operating rules:
+
+- **Do not `cd` unless explicitly instructed to** in the user's prompt. Run all commands from the inherited cwd.
+- **The "repo root" for workspace commands** (npm/bun/pnpm/yarn `--filter`, `-w`, `--workspace`) is whatever directory contains the active `package.json` and lockfile. From a worktree, that is the worktree's own root — *not* the primary checkout.
+- **If unsure about your cwd**, run `pwd` and `git rev-parse --show-toplevel` once at the start of your work. Verify they point to the same directory or to a worktree under `.claude/worktrees/`.
+- **If you need to chain multiple commands** that touch different paths, use absolute paths in command arguments (e.g., `cat /abs/path/to/file`) rather than `cd /abs/path/to/dir && cat file`. The first preserves cwd; the second loses it.
+
 ## Available Test Commands
 
-- `npm run test` - Unit tests only (Vitest)
-- `npm run test:e2e` - E2E tests only (Playwright)
-- `npm run test:all` - Complete test suite (unit + E2E)
-- `npm run test:coverage` - Unit tests with coverage report
+Choose the commands that match the project's package manager and test runner. Inspect `package.json` and the lockfile to determine which toolchain is in use; do not assume npm.
+
+**npm projects (single-package):**
+- `npm run test` — unit tests (commonly Vitest or Jest)
+- `npm run test:e2e` — E2E tests (commonly Playwright)
+- `npm run test:all` — complete suite
+- `npm run test:coverage` — unit tests with coverage
+
+**Bun workspace monorepos:**
+- `bun --filter='<package-name>' run test` — run `test` script in a specific workspace package
+- `bun --filter='*' run test` — run `test` script in every workspace that defines one
+- `bun test` — Bun's built-in test runner from inside a workspace
+- Same `--filter` pattern for `typecheck`, `test:e2e`, `lint`, etc.
+
+**Other patterns** (pnpm, yarn workspaces, turbo): match the project's `package.json` scripts and existing CI invocations. If no test script is defined in the relevant workspace's `package.json`, report that as the failure rather than reaching for an invented invocation.
+
+## Failure Discipline
+
+When a command fails in an unexpected way, **re-verify state before theorizing**:
+
+1. `pwd` — am I where I expect to be?
+2. `git rev-parse --show-toplevel` and `git branch --show-current` — am I on the expected branch in the expected worktree?
+3. `cat <relevant package.json>` and `ls <relevant directories>` — does the file/state match what the prompt assumed?
+4. Only after grounding state in observation, propose a hypothesis about why the command failed.
+
+**Never propose destructive remediation** — `git checkout HEAD -- <paths>`, `git reset --hard`, `git clean -fd`, `git restore .`, etc. — without explicit user authorization in the current request. If a state-sync seems needed, surface the observed state and ask the user; do not propose the destructive command as a fix.
+
+**Report failures mechanically.** Quote the exit code, the relevant stderr lines, and the exact command invoked. Do not synthesize a diagnosis when the simpler explanation is "I am in the wrong directory" or "I called the wrong tool."
 
 ## Analysis Checklist
 

--- a/plugins/dev-workflow/agents/test-runner.md
+++ b/plugins/dev-workflow/agents/test-runner.md
@@ -20,14 +20,15 @@ Your responsibility is to execute the appropriate test suite, analyze results, a
 
 ## Working Directory Discipline
 
-You may be invoked from a git worktree. Worktrees live under `.claude/worktrees/<name>/` and have their own working directory (with their own `package.json`, `bun.lock` / `package-lock.json`, and source tree) while sharing `.git/` with the primary checkout. **Never `cd` to an assumed canonical project path** like `/Users/<user>/Developer/<project>/` — the parent session's inherited cwd is the correct one, and cd'ing elsewhere will land you in the wrong working tree.
+You may be invoked from a git worktree. Worktrees live under `.claude/worktrees/<name>/` and have their own working directory (with their own `package.json`, `bun.lock` / `bun.lockb` / `package-lock.json`, and source tree) while sharing `.git/` with the primary checkout. **Never `cd` to an assumed canonical project path** like `/Users/<user>/Developer/<project>/` — the parent session's inherited cwd is the correct one, and cd'ing elsewhere will land you in the wrong working tree.
 
 Operating rules:
 
-- **Do not `cd` unless explicitly instructed to** in the user's prompt. Run all commands from the inherited cwd.
+- **Do not `cd` to a different project root or canonical checkout path.** Navigating to a subdirectory within the inherited working tree is fine (e.g., `cd apps/some-package && bun test` from the worktree root); leaving the worktree is not.
 - **The "repo root" for workspace commands** (npm/bun/pnpm/yarn `--filter`, `-w`, `--workspace`) is whatever directory contains the active `package.json` and lockfile. From a worktree, that is the worktree's own root — *not* the primary checkout.
 - **If unsure about your cwd**, run `pwd` and `git rev-parse --show-toplevel` once at the start of your work. Verify they point to the same directory or to a worktree under `.claude/worktrees/`.
-- **If you need to chain multiple commands** that touch different paths, use absolute paths in command arguments (e.g., `cat /abs/path/to/file`) rather than `cd /abs/path/to/dir && cat file`. The first preserves cwd; the second loses it.
+- **Do not run install commands** (`bun install`, `npm install`, `pnpm install`, `yarn install`) during test execution unless the prompt explicitly requests it. Install commands are not part of test verification and can mask which directory you're operating in.
+- **If you need to chain multiple commands** that touch different paths, use absolute paths in command arguments (e.g., `cat /abs/path/to/file`) rather than `cd /abs/path/to/dir && cat file`. The first preserves cwd; the second loses it. **Derive absolute paths from `pwd` or `git rev-parse --show-toplevel`** — never construct them by appending to an assumed canonical root.
 
 ## Available Test Commands
 
@@ -45,7 +46,19 @@ Choose the commands that match the project's package manager and test runner. In
 - `bun test` — Bun's built-in test runner from inside a workspace
 - Same `--filter` pattern for `typecheck`, `test:e2e`, `lint`, etc.
 
-**Other patterns** (pnpm, yarn workspaces, turbo): match the project's `package.json` scripts and existing CI invocations. If no test script is defined in the relevant workspace's `package.json`, report that as the failure rather than reaching for an invented invocation.
+**pnpm workspaces:**
+- `pnpm --filter <package> run test` — run `test` script in a specific workspace
+- `pnpm -r run test` — recursively in all workspaces that define one
+
+**Yarn workspaces:**
+- `yarn workspace <package> run test` — run `test` script in a specific workspace
+- `yarn workspaces foreach run test` — across all workspaces
+
+**Turbo:**
+- `turbo run test --filter=<package>` — scoped to a workspace
+- `turbo run test` — across the whole monorepo
+
+**Anything else**: match the project's `package.json` scripts and existing CI invocations. If no test script is defined in the relevant workspace's `package.json`, report that as the failure rather than reaching for an invented invocation.
 
 ## Failure Discipline
 
@@ -53,7 +66,7 @@ When a command fails in an unexpected way, **re-verify state before theorizing**
 
 1. `pwd` — am I where I expect to be?
 2. `git rev-parse --show-toplevel` and `git branch --show-current` — am I on the expected branch in the expected worktree?
-3. `cat <relevant package.json>` and `ls <relevant directories>` — does the file/state match what the prompt assumed?
+3. `cat ./package.json` and `ls .` (or relative paths into subdirectories — never absolute paths constructed from assumed roots) — does the file/state match what the prompt assumed?
 4. Only after grounding state in observation, propose a hypothesis about why the command failed.
 
 **Never propose destructive remediation** — `git checkout HEAD -- <paths>`, `git reset --hard`, `git clean -fd`, `git restore .`, etc. — without explicit user authorization in the current request. If a state-sync seems needed, surface the observed state and ask the user; do not propose the destructive command as a fix.


### PR DESCRIPTION
## Summary

Three additions to the `dev-workflow:test-runner` agent prompt to prevent the failure mode observed on 2026-05-12 in a wellstead session (wellstead PR #119 context).

- **Working Directory Discipline** — warns the agent against `cd`'ing to assumed canonical project paths; explains how worktrees expose independent working trees through a shared `.git/`; requires `pwd` + `git rev-parse --show-toplevel` when uncertain about cwd.
- **Available Test Commands (expanded)** — covers Bun workspace monorepos (`--filter='<pkg>'`, `--filter='*'`, `bun test`) and pnpm/yarn/turbo patterns. Instructs the agent to inspect `package.json` and the lockfile rather than assume npm.
- **Failure Discipline** — requires re-verifying cwd / branch / file state before theorizing about errors; prohibits proposing destructive git remediation (`git checkout HEAD -- <paths>`, `git reset --hard`, etc.) without explicit user authorization in the current request; requires mechanical failure reporting (exit code, stderr, exact command invoked).

## Failure mode being addressed

In the incident, the agent was invoked from a wellstead worktree (`.claude/worktrees/phase-0-scaffold/`) and asked to run `bun --filter='@wellstead/mcp-server' run typecheck` and `... run test` for verification. It:

1. Verified its inherited cwd was the worktree ✓
2. On its first command, ran `bun install` — landing in the user's primary checkout
3. Continued chaining `cd /Users/derek/Developer/wellstead && ...` on every subsequent command, all running on `main` where the feature branch's source files don't exist
4. After commands started failing in the (wrong) directory, theorized "worktree out of sync" and proposed `git checkout HEAD -- apps/mcp-server/src` to "sync" it
5. The auto-mode classifier correctly blocked the destructive command (the user had bounded the task to verification only); the agent then reported "permission denials" as the blocker rather than recognizing it had wandered out of the worktree

Three contributing factors in the agent definition:
- No worktree awareness; hardcoding canonical paths looked natural
- Test-commands list was npm-only; mismatch left the agent reaching for unfamiliar invocations under pressure
- No failure-discipline note; on unexpected errors the agent theorized about state instead of re-verifying basics

## Deliberate non-change

`model: haiku` is unchanged. Haiku is a contributing-but-not-primary factor — fine for happy-path test parsing, weaker at diagnostic recovery. Holding off on a model bump per `~/.claude/rules/pattern-not-incident.md` (N=1 incident); revisit if the prompt fix alone proves insufficient on a future invocation.

## Scope

Single-file markdown edit to `plugins/dev-workflow/agents/test-runner.md`. Sibling agents (`branch-creator.md`, `commit-creator.md`, `pr-manager.md`, `chrome-verifier.md`, `linear-issues.md`) were checked for the same npm-only and worktree-naivete gaps; none had matching markers, so they're out of scope for this PR.

## Test plan

- [ ] Re-invoke `dev-workflow:test-runner` from a wellstead worktree on a similar verification task; confirm it stays in the inherited cwd and uses Bun-appropriate commands
- [ ] On an intentionally-broken command, confirm the agent re-verifies state before theorizing rather than confabulating a state-sync diagnosis
- [ ] Confirm the agent does not propose destructive git remediation when verification was the bounded task