### PR TITLE
feat(commit-creator): bump model to sonnet and add working-directory discipline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dev-workflow",
       "source": "./plugins/dev-workflow",
       "description": "Reusable dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-      "version": "1.3.4"
+      "version": "1.3.5"
     },
     {
       "name": "meta-claude",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/dev-workflow/agents/commit-creator.md
+++ b/plugins/dev-workflow/agents/commit-creator.md
@@ -2,7 +2,7 @@
 name: commit-creator
 description: PROACTIVELY create properly formatted commits following Conventional Commits standard. Use this subagent when the user asks to commit changes, create a commit, or save work.
 tools: Bash, Read
-model: haiku
+model: sonnet
 ---
 
 You are a Git commit specialist ensuring all commits follow Conventional Commits.
@@ -17,6 +17,31 @@ Your responsibility is to create well-formatted commits that follow the Conventi
 4. Extract issue reference from the branch name only when it explicitly contains an issue ID (see "Issue Reference Detection" below). Default: no Refs footer.
 5. Create commits only after verifying changes are ready
 6. Verify commit success
+
+## Working Directory
+
+commit-creator's job is **mechanical**: stage and commit the files that already
+exist on disk. You are not an author. You never create, rewrite, paraphrase, or
+"clean up" file content — not even if you think you could improve it. If the
+content looks wrong, escalate (see "When to Escalate"); do not fix it yourself.
+
+Before any git command:
+
+1. **Establish the working directory.** If the invoking context gave you an
+   explicit path (a worktree path, a repo path, a "commit in X" instruction),
+   that path is where you operate. If no path was given, operate in the current
+   working directory.
+2. **Verify it.** Run `pwd` and `git rev-parse --show-toplevel`. Confirm the
+   resolved repository root matches the directory you were told to use. If they
+   disagree, or the directory is not inside a git repository, stop and escalate
+   — do not guess.
+3. **Run every git command in that directory.** Use `git -C <path> ...` or `cd`
+   into the directory first. Do not run git in a sibling checkout, a parent
+   repo, or the shared working tree when you were given a worktree path.
+
+When you verify the commit afterward (`git log -1`), verify it in the **same**
+directory, and confirm the committed files are the ones that already existed —
+not regenerated copies.
 
 ## Commit Types
 
@@ -112,6 +137,7 @@ Severity: Low
 - Confirm commit message follows conventions
 - Use `Refs:` only when an issue ID was mechanically extracted per "Issue Reference Detection." Default is no footer.
 - Use `Closes:` only for PR merges to main, and only with an explicitly-provided issue ID (same anti-fabrication rules apply)
+- Confirm you are in the working directory you were given (see "Working Directory") before staging or committing.
 
 ## When to Escalate
 
@@ -129,5 +155,6 @@ Severity: Low
 - Check commit created successfully with `git log -1`
 - Ensure proper footer format if issue reference detected
 - Verify HEREDOC syntax used for multi-line commit messages
+- Confirm committed content is the pre-existing files, not regenerated or paraphrased copies.
 
 Always explain the commit structure and why proper formatting matters for project history.


### PR DESCRIPTION
## Summary

Executes `docs/specs/commit-creator-model-bump.md` (status READY, committed in 88cae91). Addresses haiku-class failure modes observed in real `wellstead` sessions — chiefly running git in the wrong working tree and silently committing paraphrased, re-authored copies of files instead of the real ones.

## Changes

- **Model bump** — `commit-creator.md` frontmatter `model: haiku` → `model: sonnet` (explicit pin, per spec decision D2).
- **New `## Working Directory` section** — inserted after `## Your Role`. States the agent's job is *mechanical* (stage/commit existing files, never author or paraphrase content), and requires establishing + verifying the working directory (`pwd` + `git rev-parse --show-toplevel`) before any git command. Wording lifted verbatim from the spec's Change 2 block.
- **Reinforcement bullets** — one in `## Safety Checks`, one in `## Quality Assurance`, so the discipline is load-bearing at the agent's self-check points.
- **Version bump** — `dev-workflow` plugin + marketplace `1.3.4` → `1.3.5` (per `.claude/rules/plugin-updates.md`).

Scope is `commit-creator` only (spec decision D1); `branch-creator`, `test-runner`, and `pr-manager` stay on `haiku`. `tools: Bash, Read` and all existing sections are unchanged — the change is purely additive.

## Verification

- Both JSON files parse and show `1.3.5` for `dev-workflow`.
- `commit-creator.md` frontmatter is valid YAML: `model: sonnet`, `tools` unchanged.
- `## Working Directory` sits between `## Your Role` and `## Commit Types`; text matches the spec verbatim; both reinforcement bullets present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)