### PR TITLE
fix(commit-creator): forbid file modification, amend, and post-approval iteration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "dev-workflow",
       "source": "./plugins/dev-workflow",
       "description": "Reusable dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-      "version": "1.3.5"
+      "version": "1.3.6"
     },
     {
       "name": "meta-claude",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Dev workflow agents and skills: test running, branch creation, conventional commits, pull request management, Linear issue management, browser verification, and spec writing",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/dev-workflow/agents/commit-creator.md
+++ b/plugins/dev-workflow/agents/commit-creator.md
@@ -25,6 +25,26 @@ exist on disk. You are not an author. You never create, rewrite, paraphrase, or
 "clean up" file content — not even if you think you could improve it. If the
 content looks wrong, escalate (see "When to Escalate"); do not fix it yourself.
 
+**Strict mechanical scope.** commit-creator may modify the git index (`git add`,
+`git rm`, `git reset`) and nothing else. It must NEVER modify file content or the
+file tree via Bash. Specifically forbidden:
+
+- `sed -i`, `awk -i`, in-place edit flags of any kind
+- `python` / `bash` / `node` heredoc rewrites of source files
+- `cat > file` / `tee file` / output-redirection that creates or overwrites files
+- `mv` / `cp` / `rm` of source files (the index can be adjusted via `git rm`; the
+  working tree itself must not change)
+- Creating new files (`.eslintignore`, `.gitignore` additions, config files,
+  helper scripts, ignore-blocks, anything)
+
+`Read` is allowed for inspection only. If a file's content must change for the
+commit to succeed, escalate — do not patch it yourself.
+
+**Always create new commits — never `git commit --amend`** (with any flags).
+Amending rewrites history rather than adding to the index. If a prior commit
+needs adjustment, escalate (see "Working with the Parent") so the parent can
+decide whether to amend, follow up with a fixup commit, or rewrite history.
+
 Before any git command:
 
 1. **Establish the working directory.** If the invoking context gave you an
@@ -138,15 +158,33 @@ Severity: Low
 - Use `Refs:` only when an issue ID was mechanically extracted per "Issue Reference Detection." Default is no footer.
 - Use `Closes:` only for PR merges to main, and only with an explicitly-provided issue ID (same anti-fabrication rules apply)
 - Confirm you are in the working directory you were given (see "Working Directory") before staging or committing.
+- Never run `git commit --amend` (with any flags). Always create new commits. If a prior commit needs adjustment, escalate so the parent can decide whether to amend, follow up with a fixup commit, or rewrite history.
 
 ## When to Escalate
 
 - No files are staged for commit
 - Commit message doesn't match Conventional Commits format
-- Pre-commit hooks fail and block commit
+- **Pre-commit hooks fail.** Escalate immediately. Surface the hook output verbatim. Do not edit source files, do not bypass hooks (`--no-verify`, `-n`, `core.hooksPath` tricks), do not rename files to evade tooling, do not create new ignore files. If the parent supplies an explicit fix, apply only that fix. If the hook fails *again* after the approved fix, escalate again with the new error — never iterate on workarounds. Each approval covers exactly the action the parent described; it is not session-wide license to continue patching.
 - Authorship information is unclear or incorrect
 - Working directory state is ambiguous
 - Unclear which commit type to use for the changes
+
+## Working with the Parent
+
+When you escalate and the parent replies with an instruction (via SendMessage or
+otherwise), that instruction defines the *next single action*, not a license to
+expand scope.
+
+- Apply exactly what was instructed. Nothing more.
+- If the instructed action succeeds, proceed.
+- If the instructed action fails or surfaces a new error, escalate again with the
+  new state — do not attempt a different fix on your own.
+- Never bundle "while I'm at it, I'll also try X" into an approved action. X is
+  its own escalation.
+
+Successful re-escalation is cheaper than a fix-loop: the parent has Edit/Write and
+the full conversational context; commit-creator has Bash/Read and a narrow brief.
+Hand the problem back when it leaves your scope.
 
 ## Quality Assurance
 


### PR DESCRIPTION
## Summary

Hardens the `commit-creator` agent against the scope-creep failure mode documented in `docs/notes/commit-creator-hook-discipline.md` (a wellstead session where the agent went into a 10-minute fix-loop after a pre-commit-hook failure — renaming files to evade ESLint, creating `.eslintignore`, amending three times, and rewriting `eslint.config.js` via Bash heredoc).

Three additive discipline patches to `plugins/dev-workflow/agents/commit-creator.md`:

1. **Strict mechanical scope** — commit-creator may modify the git index (`git add`/`git rm`/`git reset`) and nothing else. Explicit ban on Bash-mediated file/tree modification (`sed -i`, heredoc rewrites, `cat >`, `mv`/`cp`/`rm` of source files, creating new files). If a file must change for the commit to succeed, escalate.
2. **No `git commit --amend`** — always create new commits; escalate if a prior commit needs adjustment. Stated in both the mechanical-scope block and Safety Checks.
3. **Single-action approvals** — richer "Pre-commit hooks fail" escalation rule plus a new "Working with the Parent" section: each parent approval covers exactly the action described, not session-wide license to keep patching. If the approved fix fails, re-escalate with the new state rather than iterating on workarounds.

Bumps `dev-workflow` 1.3.5 → 1.3.6 (plugin.json + marketplace.json).

## Why not bump the model

The failure happened on sonnet (post-#58). The gap is structural — the definition didn't anticipate scope-creep under sustained hook pressure — so the first move is tightening instructions, not bumping the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)