### PR TITLE
feat(knowledge-commons): proactive entity recommendation, silence-as-error, and target refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "knowledge-commons",
       "source": "./plugins/knowledge-commons",
       "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons",
-      "version": "0.1.9"
+      "version": "0.2.0"
     }
   ]
 }

--- a/plugins/knowledge-commons/.claude-plugin/plugin.json
+++ b/plugins/knowledge-commons/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-commons",
   "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/knowledge-commons/README.md
+++ b/plugins/knowledge-commons/README.md
@@ -138,6 +138,7 @@ plugins/knowledge-commons/
     promote/SKILL.md                  # the cross-domain derivation mechanism
   references/
     graph-conventions.md              # the shared note/map/frontmatter contract
+    deltas.md                         # template fixes to propagate into generated skills
     templates/
       process.md                      # → generated <project>/.claude/skills/process
       knowledge-graph.md              # → generated <project>/.claude/skills/knowledge-graph

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -92,8 +92,10 @@ Entries are append-only and ordered by version.
   version: 0.2.0
   instruction: >
     Gate the processed: stamp on inspection coverage. Refuse to write it while any signal class
-    has neither returned findings nor explicitly reported none. Instead, withhold the stamp, name
-    the unaccounted-for classes, and offer the re-read.
+    handed to a subagent has neither returned findings nor explicitly reported none. Instead,
+    withhold the stamp, name the unaccounted-for classes, and offer the re-read. Scope the gate to
+    the fanout path explicitly: on an inline read there are no readers to hear from and every class
+    was inspected in-conversation, so an unscoped gate would withhold the stamp on a complete run.
   rationale: >
     The stamp is what makes re-runs resume instead of redo, so writing one marks the source
     handled for good — the next run reads it and moves on. Stamping over a class that was never
@@ -102,8 +104,9 @@ Entries are append-only and ordered by version.
     be re-run, a complete-looking stamp over an uninspected class cannot be distinguished from a
     finished one afterward.
   satisfied-test: >
-    Does the section make writing the stamp conditional on every signal class having either
-    reported findings or explicitly reported none, and say what to do instead when one has not?
+    Does the section make writing the stamp conditional on every fanned-out signal class having
+    either reported findings or explicitly reported none, and say what to do instead when one has
+    not — while leaving an inline read, where no subagent was involved, free to stamp normally?
 
 - id: step11-pull-target
   file: process
@@ -113,8 +116,10 @@ Entries are append-only and ordered by version.
     Refresh the promotion target before the screen runs — not after candidates are derived. If
     the target is a git repo with a remote, fetch and fast-forward, and say what came in, since
     new claims in the target change the screen's answer. Degrade explicitly: with no remote, no
-    network, or no git, the screen still runs, but state that it ran against a possibly-stale
-    copy rather than letting silence imply the target is current.
+    network, no git, a fetch error, or a fetch that returns cleanly while the fast-forward is
+    refused (diverged local copy, dirty tree), the screen still runs, but state that it ran
+    against a possibly-stale copy rather than letting silence imply the target is current. The
+    check is that the fast-forward happened, not that the fetch returned.
   rationale: >
     Found while promoting five claims into the personal commons. The "not already steering"
     screen reads the target graph from the local working copy without fetching; against a stale
@@ -125,18 +130,24 @@ Entries are append-only and ordered by version.
     screened against.
   satisfied-test: >
     Does the section require refreshing the target graph from its remote before the redundancy
-    screen runs, and require saying so explicitly when the refresh is skipped or fails?
+    screen runs, and require saying so explicitly whenever the copy did not reach the remote's
+    tip — including when a fetch succeeds but the fast-forward is refused?
 
 - id: step4-entity-signal-class
   file: process
   anchor: "## 4. Inspect"
   version: 0.2.0
   instruction: >
-    Make entity recognition a first-class inspection concern: named nouns this graph tracks that
-    have no entity note yet are a finding in their own right, not a side effect of writing an
-    observation that mentions one. Both the inline-read path and the subagent-fanout path look
-    for them, and both carry the mention count forward to the plan. Add the entity class to this
-    graph's signal-class list, phrased in the domain's own vocabulary for the nouns it tracks.
+    APPLIES ONLY IF this graph declares an entity type in .commons.yml. The entity tier is
+    optional — a graph whose interview answered "none" has no entity type, no scaffolded entity
+    directory, and no map to enter one in. For such a graph this delta does not apply: report it
+    as not applicable and propose no edit.
+    Where it does apply: make entity recognition a first-class inspection concern: named nouns
+    this graph tracks that have no entity note yet are a finding in their own right, not a side
+    effect of writing an observation that mentions one. Both the inline-read path and the
+    subagent-fanout path look for them, and both carry the mention count forward to the plan. Add
+    an unnamed-entities class to this graph's signal-class list, phrased in the domain's own
+    vocabulary for the nouns it tracks.
   rationale: >
     Entity creation was reactive and conditional — the only rule anywhere was "if the entry names
     a plugin or skill not yet in entities/, add a lookup-only entity note," buried as one step of
@@ -146,19 +157,25 @@ Entries are append-only and ordered by version.
     so an entity clearly worth a note but with nothing attaching to it was invisible to the run.
     The mention count is what lets the plan make the case at step 5.
   satisfied-test: >
-    Does inspection treat unnamed entities — nouns the graph tracks with no entity note yet — as
-    a signal class of their own, found on both the inline and fanout paths, independently of
-    whether any observation in the run attaches to them?
+    First, does this graph declare an entity type in .commons.yml? If not, the delta is not
+    applicable and the section is correct as it stands. If it does: does inspection treat unnamed
+    entities — nouns the graph tracks with no entity note yet — as a signal class of their own,
+    found on both the inline and fanout paths, independently of whether any observation in the
+    run attaches to them?
 
 - id: step5-entity-recommend
   file: process
   anchor: "## 5. Propose the plan"
   version: 0.2.0
   instruction: >
-    The plan surfaces entity recommendations as their own line items — naming the noun, its
-    mention count for this run, and that it has no entity note yet — rather than folding them
-    into the notes that mention them. Shape: "this run named X and Y four times each; neither has
-    an entity note; create them?"
+    APPLIES ONLY IF this graph declares an entity type in .commons.yml — same applicability test
+    as step4-entity-signal-class, and the two travel together: apply both or neither. For a graph
+    with no entity tier, report not applicable and propose no edit; a plan that recommends
+    entities there proposes writes into a directory that was never scaffolded.
+    Where it applies: the plan surfaces entity recommendations as their own line items — naming
+    the noun, its mention count for this run, and that it has no entity note yet — rather than
+    folding them into the notes that mention them. Shape: "this run named X and Y four times
+    each; neither has an entity note; create them?"
   rationale: >
     Companion to step4-entity-signal-class: step 4 finds the entity, step 5 is where the human
     gets to approve it. Without an explicit line item, an entity that plainly warrants a note but
@@ -166,6 +183,8 @@ Entries are append-only and ordered by version.
     discarded at exactly the point it was supposed to become actionable. The count is what makes
     the case reviewable — the reader judges from the evidence rather than from an assertion.
   satisfied-test: >
-    Does the plan present entity recommendations as explicit, separately-approvable line items
-    carrying the mention count, rather than as a consequence of the observations being written?
+    First, does this graph declare an entity type in .commons.yml? If not, the delta is not
+    applicable and the section is correct as it stands. If it does: does the plan present entity
+    recommendations as explicit, separately-approvable line items carrying the mention count,
+    rather than as a consequence of the observations being written?
 ```

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -1,0 +1,171 @@
+# Template deltas
+
+`graph-init` generates two project-owned skills from the templates in `references/templates/`:
+`process/SKILL.md` and `knowledge-graph/SKILL.md`. Projects own those files and are told to sharpen them
+from real runs, which they do — measured across the three graphs generated so far, section bodies diverge
+by up to 78% while the `## N. Title` headings survive byte-identical. That is what this log is for:
+regenerating a graph would destroy the local prose, and hand-editing three graphs doesn't scale and rots
+silently. A delta describes a template fix in terms an agent can re-apply *into* diverged prose, in the
+project's own voice, rather than as text to paste.
+
+**A template edit is incomplete without its delta entry.** This sits alongside the mandatory version-bump
+rule and works the same way: stated as non-optional, applied by whoever makes the edit. A template fix
+with no delta leaves the plugin looking correct while every already-generated graph stays broken, with
+nothing that surfaces the gap — which is the same silent-loss shape most of these deltas were written to
+fix.
+
+Only **generated** files need deltas. Fixes to `graph-init` and `promote` live in the plugin and reach
+every project on plugin update; they must not appear here.
+
+## The seven fields
+
+| Field | Purpose |
+|---|---|
+| `id` | Stable kebab-case identifier. Recorded in the project's `.commons.yml` `applied:` list, so it can never be renamed once shipped. |
+| `file` | `process` or `knowledge-graph`. |
+| `anchor` | The **exact `##` heading text** the change targets — not a pattern, not a section number. A delta whose anchor doesn't resolve is skipped and reported loudly, never relocated by guess. |
+| `version` | The plugin version that introduced the delta. |
+| `instruction` | The semantic change, in domain-neutral terms. What must be true of the section afterward — not the words to insert. |
+| `rationale` | *Why* the change exists, including how the defect was found. This is what lets an agent adapt the edit to prose that has diverged from the template instead of pasting into it. |
+| `satisfied-test` | An explicit test for "does the target section already say this?" |
+
+**Write the `satisfied-test` carefully.** It is load-bearing in both directions: the patcher runs it
+*before* proposing, so a project that already hand-fixed the defect is reported as satisfied rather than
+edited twice; and it runs *again* after the edit as the post-condition proving the change landed. A vague
+test breaks both at once, and it breaks them quietly — redundancy detection starts producing duplicate
+edits, and verification starts passing on edits that did nothing. Make it a question an agent reading an
+unfamiliar, heavily-rewritten version of that section can answer reliably, about substance rather than
+wording.
+
+Entries are append-only and ordered by version.
+
+## Entries
+
+```yaml
+- id: step4-explicit-negative
+  file: process
+  anchor: "## 4. Inspect"
+  version: 0.2.0
+  instruction: >
+    A signal-class subagent that returns nothing is an error condition to chase, never a null
+    result to accept. Require an explicit "nothing in this class" statement, from that reader
+    about that class, before recording the class as empty; silence, an empty message, and a
+    reader that simply stopped are none of them that statement. Follow up to get the findings,
+    and if the reader still won't report, treat the class as failed rather than empty and route
+    it into the continue-and-collect step.
+  rationale: >
+    On the first real /process run, all four signal-class subagents completed their reads and went
+    idle without volunteering findings — four of four, so it is a property of the fanout, not a
+    fluke. Each needed an explicit follow-up before reporting. A run reading that silence as
+    "nothing found" would assemble a plan from zero findings, write the source note, stamp it
+    processed with an empty ran: list, and report a clean sweep — and because the stamp is what
+    makes re-runs resume instead of redo, the source would be permanently marked handled. The
+    failure mode is indistinguishable from a successful run. The four readers had actually
+    produced 3 patterns and 9 observations, including three divergences between the session's
+    self-account and what the transcript showed.
+  satisfied-test: >
+    Does the section state that a silent or non-reporting subagent is an error to chase rather
+    than an empty result, and require an explicit statement of "nothing found" from the reader
+    before a class may be recorded as empty?
+
+- id: step8-collect-nonreporting
+  file: process
+  anchor: "## 8. Continue-and-collect"
+  version: 0.2.0
+  instruction: >
+    A signal-class reader that never reported is a failure collected and reported by this step,
+    even though it failed before the plan existed. Name it under its class name, state plainly
+    that the class was never inspected, and offer the re-read alongside the other retries.
+  rationale: >
+    Companion to step4-explicit-negative. Step 4 makes a silent reader an error; this is where
+    the error has to surface, or the run's report says nothing went wrong. It is the one failure
+    with no error message attached to it, so a collect step that only gathers steps which threw
+    will never mention it — leaving the report indistinguishable from a clean run, which is the
+    exact defect being fixed.
+  satisfied-test: >
+    Does the section route a non-reporting or silent signal-class reader into the collected
+    failure report, naming the class and saying it was never inspected?
+
+- id: step9-stamp-gate
+  file: process
+  anchor: "## 9. Stamp"
+  version: 0.2.0
+  instruction: >
+    Gate the processed: stamp on inspection coverage. Refuse to write it while any signal class
+    has neither returned findings nor explicitly reported none. Instead, withhold the stamp, name
+    the unaccounted-for classes, and offer the re-read.
+  rationale: >
+    The stamp is what makes re-runs resume instead of redo, so writing one marks the source
+    handled for good — the next run reads it and moves on. Stamping over a class that was never
+    inspected discards that part of the input silently and permanently. The gate is the last
+    point at which the silent-reader failure is still recoverable: an unstamped partial run can
+    be re-run, a complete-looking stamp over an uninspected class cannot be distinguished from a
+    finished one afterward.
+  satisfied-test: >
+    Does the section make writing the stamp conditional on every signal class having either
+    reported findings or explicitly reported none, and say what to do instead when one has not?
+
+- id: step11-pull-target
+  file: process
+  anchor: "## 11. The promotion tail"
+  version: 0.2.0
+  instruction: >
+    Refresh the promotion target before the screen runs — not after candidates are derived. If
+    the target is a git repo with a remote, fetch and fast-forward, and say what came in, since
+    new claims in the target change the screen's answer. Degrade explicitly: with no remote, no
+    network, or no git, the screen still runs, but state that it ran against a possibly-stale
+    copy rather than letting silence imply the target is current.
+  rationale: >
+    Found while promoting five claims into the personal commons. The "not already steering"
+    screen reads the target graph from the local working copy without fetching; against a stale
+    copy it cannot see recent claims, so duplicates read as novel. Redundancy detection is the
+    screen's entire job, so a stale copy makes it decorative while it still reports clean. The
+    ordering is the substance of the fix: the screen runs before the plan is presented, so a
+    refresh that happens after candidates are derived is too late to change what they were
+    screened against.
+  satisfied-test: >
+    Does the section require refreshing the target graph from its remote before the redundancy
+    screen runs, and require saying so explicitly when the refresh is skipped or fails?
+
+- id: step4-entity-signal-class
+  file: process
+  anchor: "## 4. Inspect"
+  version: 0.2.0
+  instruction: >
+    Make entity recognition a first-class inspection concern: named nouns this graph tracks that
+    have no entity note yet are a finding in their own right, not a side effect of writing an
+    observation that mentions one. Both the inline-read path and the subagent-fanout path look
+    for them, and both carry the mention count forward to the plan. Add the entity class to this
+    graph's signal-class list, phrased in the domain's own vocabulary for the nouns it tracks.
+  rationale: >
+    Entity creation was reactive and conditional — the only rule anywhere was "if the entry names
+    a plugin or skill not yet in entities/, add a lookup-only entity note," buried as one step of
+    the sibling knowledge-graph skill's per-observation workflow. It fired only as a side effect
+    of writing an observation that happened to mention a noun. With no entity signal class,
+    inspection had no way to treat a named noun the graph keeps returning to as a finding at all,
+    so an entity clearly worth a note but with nothing attaching to it was invisible to the run.
+    The mention count is what lets the plan make the case at step 5.
+  satisfied-test: >
+    Does inspection treat unnamed entities — nouns the graph tracks with no entity note yet — as
+    a signal class of their own, found on both the inline and fanout paths, independently of
+    whether any observation in the run attaches to them?
+
+- id: step5-entity-recommend
+  file: process
+  anchor: "## 5. Propose the plan"
+  version: 0.2.0
+  instruction: >
+    The plan surfaces entity recommendations as their own line items — naming the noun, its
+    mention count for this run, and that it has no entity note yet — rather than folding them
+    into the notes that mention them. Shape: "this run named X and Y four times each; neither has
+    an entity note; create them?"
+  rationale: >
+    Companion to step4-entity-signal-class: step 4 finds the entity, step 5 is where the human
+    gets to approve it. Without an explicit line item, an entity that plainly warrants a note but
+    has no observation attaching to it never reaches the approval gate, so the finding is
+    discarded at exactly the point it was supposed to become actionable. The count is what makes
+    the case reviewable — the reader judges from the evidence rather than from an assertion.
+  satisfied-test: >
+    Does the plan present entity recommendations as explicit, separately-approvable line items
+    carrying the mention count, rather than as a consequence of the observations being written?
+```

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -100,6 +100,13 @@ Neither is an empty message, nor a reader that simply stopped. Chase it — foll
 class's findings, and ask again if the second reply is no better. If it still won't report, the class
 has failed, not come back empty; route it into step 8.
 
+<!-- SLOT: entity-inspection — CONDITIONAL. Include the paragraph below only if .commons.yml declares an
+entity type. Block 2's entity question is answerable with "none," and a graph that answered so has no
+entity type, no scaffolded entity directory, and no map to enter one in — so there is nothing for this
+paragraph to write into. Omit it entirely rather than leaving it to hunt for notes that have nowhere to
+go. It travels with the entity-recommendation slot in step 5: keep both or drop both, they are one
+feature. -->
+
 Inspection also looks for **entities** — the named nouns this graph keeps returning to that don't have an
 entity note yet. Treat this as a finding in its own right rather than a side effect of writing something
 else: a noun the input names repeatedly earns a note whether or not any observation in this run happens
@@ -110,10 +117,13 @@ to make the case.
 ("what signal classes should inspection look for"). Name each class plainly (what it is, what a finding
 in that class looks like) so both the inline-read path and the subagent-fanout path use the same
 vocabulary. Keep it to what this domain actually has classes for — don't invent classes to fill space.
-One class is standing rather than domain-derived: unnamed entities. Include it, phrased in this domain's
-own vocabulary for the nouns it tracks (this graph's entity type from .commons.yml), so the fanout has a
-reader assigned to it like any other class. -->
-    Example (orchard, chronicle tier — three domain classes plus the standing entity class):
+One further class is standing rather than domain-derived, and CONDITIONAL on the same test as the
+entity-inspection slot above: if .commons.yml declares an entity type, add an unnamed-entities class,
+phrased in this domain's own vocabulary for the nouns it tracks, so the fanout has a reader assigned to
+it like any other class. If the interview answered "none" to entities, omit that class — there is no
+entity tier for its findings to land in. -->
+    Example (orchard, chronicle tier — three domain classes, plus the entity class because orchard
+    declares an entity type):
     - **Decisions.** A choice was made and a reason given — becomes a `decision` attractor or evidence
       for an existing one.
     - **Recurring friction.** The same kind of problem shows up again, named or not — becomes a
@@ -130,6 +140,11 @@ Lay out, per skill/note, what will be created and what will be updated — and j
 being skipped and why (already captured, too operational, not durable — see the sibling
 `knowledge-graph` skill's conventions). Present it as `[y / edit / explain]`. One approval gates the
 entire run; there is no per-note confirmation after this point except the re-pause condition in step 6.
+
+<!-- SLOT: entity-recommendation — CONDITIONAL, on the same test as step 4's entity-inspection slot:
+include the paragraph below only if .commons.yml declares an entity type. Keep both or drop both — a plan
+that recommends entities for a graph with no entity tier proposes writes into a directory that was never
+scaffolded. -->
 
 **Entity recommendations get their own line items**, naming the noun, how many times this run named it,
 and that it has no entity note yet — not folded into the notes that happen to mention it. An entity that
@@ -196,8 +211,10 @@ Write or update the `processed:` stamp on the source note — a YAML list entry 
 overwritten.
 
 **Don't stamp over a gap.** The stamp is what makes re-runs resume instead of redo, so writing one marks
-this source handled for good. Before writing it, confirm that every signal class either returned findings
-or explicitly reported none. A class that did neither means part of this input was never inspected, and
+this source handled for good. Before writing it, confirm that every signal class handed to a subagent
+either returned findings or explicitly reported none. (This gate is about the fanout — on the inline path
+there are no readers to hear from, and a run that read the input in this conversation has already
+inspected every class.) A class that did neither means part of this input was never inspected, and
 stamping now discards it silently and permanently — the next run reads the stamp and moves on. Withhold
 the stamp, name the unaccounted-for classes, and offer the re-read. An unstamped partial run is
 recoverable; a complete-looking stamp over an uninspected class is not.
@@ -227,8 +244,13 @@ disk. If the target is a git repository with a remote, fetch and fast-forward it
 in: new claims in the target are precisely what the screen is looking for, so they change its answer. A
 clone a few commits behind cannot see recent claims, which means duplicates read as novel — and since
 redundancy detection is the screen's whole job, stale makes it decorative while it still reports clean.
-If there is no remote, no network, or no git, the screen still runs — but say plainly that it ran against
-a possibly-stale copy, rather than letting the silence stand in for "the target is current."
+
+Treat the refresh as failed whenever the copy didn't actually end up at the remote's tip: no remote, no
+network, no git, a fetch error — and also a fetch that returns cleanly while the fast-forward is refused,
+because the local copy has diverged or the tree is dirty. Check that the fast-forward happened, not just
+that the fetch returned; a clean fetch with an unmoved `HEAD` looks identical to being up to date. In any
+of those cases the screen still runs — but say plainly that it ran against a possibly-stale copy, rather
+than letting the silence stand in for "the target is current."
 
 The screen, applied to each candidate:
 

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -89,11 +89,31 @@ Read the resolved input and decide what it contains, sized to the input:
   of findings for its class. Synthesize the returned lists yourself before moving to the plan — don't
   forward subagent output verbatim.
 
+**A silent reader is an error to chase, not an empty class.** A subagent that finishes its read and goes
+idle without volunteering findings has told you nothing. Reading that silence as "nothing found" is the
+one failure this run cannot catch on its own, because it looks exactly like a clean pass: a plan
+assembled from zero findings still writes a source note, still stamps it `processed:`, and still reports
+a sweep — while the stamp permanently marks the source handled and everything the readers actually found
+is gone. So before recording any class as empty, require the reader to say so in words: an explicit
+"nothing in this class" statement, from that reader, about that class. Silence is not that statement.
+Neither is an empty message, nor a reader that simply stopped. Chase it — follow up asking for the
+class's findings, and ask again if the second reply is no better. If it still won't report, the class
+has failed, not come back empty; route it into step 8.
+
+Inspection also looks for **entities** — the named nouns this graph keeps returning to that don't have an
+entity note yet. Treat this as a finding in its own right rather than a side effect of writing something
+else: a noun the input names repeatedly earns a note whether or not any observation in this run happens
+to attach to it. Both paths look for them, and both carry the count of mentions forward — step 5 needs it
+to make the case.
+
 <!-- SLOT: signal-classes — the signal classes inspection looks for, per tier, from interview block 3
 ("what signal classes should inspection look for"). Name each class plainly (what it is, what a finding
 in that class looks like) so both the inline-read path and the subagent-fanout path use the same
-vocabulary. Keep it to what this domain actually has classes for — don't invent classes to fill space. -->
-    Example (orchard, chronicle tier — three classes):
+vocabulary. Keep it to what this domain actually has classes for — don't invent classes to fill space.
+One class is standing rather than domain-derived: unnamed entities. Include it, phrased in this domain's
+own vocabulary for the nouns it tracks (this graph's entity type from .commons.yml), so the fanout has a
+reader assigned to it like any other class. -->
+    Example (orchard, chronicle tier — three domain classes plus the standing entity class):
     - **Decisions.** A choice was made and a reason given — becomes a `decision` attractor or evidence
       for an existing one.
     - **Recurring friction.** The same kind of problem shows up again, named or not — becomes a
@@ -101,6 +121,8 @@ vocabulary. Keep it to what this domain actually has classes for — don't inven
     - **Standalone observations.** True and useful on their own, not yet clustering with anything —
       becomes an `observation` with no attractor yet; note it as unattached in the plan rather than
       forcing a link.
+    - **Unnamed entities.** A grove, cultivar, or tool the entry keeps returning to that has no note
+      under `entities/` — becomes a lookup-only entity note, on the strength of the mentions alone.
 
 ## 5. Propose the plan
 
@@ -108,6 +130,12 @@ Lay out, per skill/note, what will be created and what will be updated — and j
 being skipped and why (already captured, too operational, not durable — see the sibling
 `knowledge-graph` skill's conventions). Present it as `[y / edit / explain]`. One approval gates the
 entire run; there is no per-note confirmation after this point except the re-pause condition in step 6.
+
+**Entity recommendations get their own line items**, naming the noun, how many times this run named it,
+and that it has no entity note yet — not folded into the notes that happen to mention it. An entity that
+plainly warrants a note but has no observation attaching to it surfaces no other way, so if it isn't a
+line in the plan you never get the chance to approve it. Give the count and let the reader judge; a
+declined entity costs one skip at review.
 
 ## 6. Run to completion
 
@@ -155,12 +183,24 @@ If a step in the approved plan fails, skip it and continue with the remaining in
 than aborting the run. Collect every failure and report them together at the end, with enough detail to
 retry (what was attempted, what error came back), and offer to retry the failed steps now.
 
+A signal-class reader that never reported (step 4) belongs here too, even though it failed before the
+plan existed. Collect it under its class name, say plainly that the class was never inspected, and offer
+the re-read alongside the other retries. It is the one failure with no error message attached to it, so
+if this step doesn't name it, the run's report says nothing went wrong.
+
 ## 9. Stamp
 
 Write or update the `processed:` stamp on the source note — a YAML list entry with `date:`, `ran:`
 (what was actually written), `skipped:` (what was deliberately not written, and why), and `errored:`
 (what failed, per step 8). It's a list so history accumulates across augment-mode runs rather than being
 overwritten.
+
+**Don't stamp over a gap.** The stamp is what makes re-runs resume instead of redo, so writing one marks
+this source handled for good. Before writing it, confirm that every signal class either returned findings
+or explicitly reported none. A class that did neither means part of this input was never inspected, and
+stamping now discards it silently and permanently — the next run reads the stamp and moves on. Withhold
+the stamp, name the unaccounted-for classes, and offer the re-read. An unstamped partial run is
+recoverable; a complete-looking stamp over an uninspected class is not.
 
 ## 10. Report
 
@@ -180,6 +220,15 @@ placeholder or an empty header. When included, fill the generalization guidance 
 After the plan in step 5 is assembled — before presenting it — ask one more question of the run's
 findings: does any of this generalize beyond `{graph.name}`? Candidates go **into the same plan**,
 clearly marked as promotions, not into a separate pass someone has to remember to run.
+
+**Refresh the target first — before the screen runs, not after the candidates are derived.** The "not
+already steering" check below reads the target's own notes, so it is worth exactly as much as the copy on
+disk. If the target is a git repository with a remote, fetch and fast-forward it now, and say what came
+in: new claims in the target are precisely what the screen is looking for, so they change its answer. A
+clone a few commits behind cannot see recent claims, which means duplicates read as novel — and since
+redundancy detection is the screen's whole job, stale makes it decorative while it still reports clean.
+If there is no remote, no network, or no git, the screen still runs — but say plainly that it ran against
+a possibly-stale copy, rather than letting the silence stand in for "the target is current."
 
 The screen, applied to each candidate:
 

--- a/plugins/knowledge-commons/skills/promote/SKILL.md
+++ b/plugins/knowledge-commons/skills/promote/SKILL.md
@@ -27,29 +27,38 @@ three enter the same flow below.
 Read the **source** graph's `.commons.yml` for exactly one value: `graph.name`. That string becomes the
 `domain:` field on the note you write. Nothing else about the source config matters here.
 
-Read the **target**'s `.commons.yml` for everything else: type names, directories, where the atlas and maps
-live. The target is named by the source's `promotes-to:` field, unless the caller named a different target
+The target is named by the source's `promotes-to:` field, unless the caller named a different target
 explicitly (e.g. promoting from the commons into `~/.claude/rules/`, which is a directory, not a graph — see
 §4).
 
-Getting these backwards is the first way this goes wrong. You are about to write into the **target**'s
-world, using the target's type names and the target's directory layout. The source config exists only to
-answer "whose domain is this."
+**Refresh the target before reading any of it.** Once you know which target, and before you read its
+config, its maps, or its notes: if it's a git repository with a remote, fetch and fast-forward — then say
+plainly what came in, including new attractors, new claims, new questions, and which domains they arrived
+from. The order is the substance here, not tidiness. §3 associates against the target's maps and checks
+redundancy against its existing claims, and both read whatever happens to be on disk; a refresh that runs
+after those reads changes nothing, because nothing re-reads. A clone a few commits behind can have gained
+principles, graduated the very question you were about to attach to, and already hold a near-duplicate of
+the claim you're deriving — none of which surfaces until the push in §6 is rejected, by which point the
+note is written and the association is already wrong.
 
-**Refresh the target before reading any of it.** If the target is a git repository with a remote, fetch
-and fast-forward before you read its config, its maps, or its notes — then say plainly what came in: new
-attractors, new claims, new questions, and which domains they arrived from. This is not housekeeping.
-§3 associates against the target's maps and checks redundancy against its existing claims, and both read
-whatever happens to be on disk. A clone a few commits behind can have gained principles, graduated the
-very question you were about to attach to, and already hold a near-duplicate of the claim you're
-deriving — none of which surfaces until the push in §6 is rejected, by which point the note is written
-and the association is already wrong.
+**A fetch that succeeds is not the same as a target that is current.** Treat it as a failed refresh
+whenever the local copy did not actually end up at the remote's tip: no remote, no network, no git, a
+fetch error — and also a fetch that returns cleanly while the fast-forward is refused, because the local
+copy has diverged or the tree is dirty. That last case is the dangerous one: `git fetch` exits 0, `HEAD`
+doesn't move, and "refreshed, nothing new" is exactly what a clone missing nine commits looks like. Check
+that the fast-forward actually happened, not merely that the fetch returned.
 
-If the fetch fails, or there is no remote, or git isn't available here, continue — but say so. A skipped
-or failed refresh must never read as "the target is current." State that the association and the
-redundancy check ran against a possibly-stale copy, so the human weighing the proposal knows what it was
-weighed against. An unreported gap that looks exactly like a clean result is the failure this whole flow
-is built to avoid.
+On any of those, continue — but say so. A skipped, failed, or refused refresh must never read as "the
+target is current." State that the association and the redundancy check ran against a possibly-stale
+copy, so the human weighing the proposal knows what it was weighed against. An unreported gap that looks
+exactly like a clean result is the failure this whole flow is built to avoid.
+
+Then read the **target**'s `.commons.yml` for everything else: type names, directories, where the atlas
+and maps live.
+
+Getting the two configs backwards is the other way this goes wrong. You are about to write into the
+**target**'s world, using the target's type names and the target's directory layout. The source config
+exists only to answer "whose domain is this."
 
 ## 2. Derive the candidate
 

--- a/plugins/knowledge-commons/skills/promote/SKILL.md
+++ b/plugins/knowledge-commons/skills/promote/SKILL.md
@@ -36,6 +36,21 @@ Getting these backwards is the first way this goes wrong. You are about to write
 world, using the target's type names and the target's directory layout. The source config exists only to
 answer "whose domain is this."
 
+**Refresh the target before reading any of it.** If the target is a git repository with a remote, fetch
+and fast-forward before you read its config, its maps, or its notes — then say plainly what came in: new
+attractors, new claims, new questions, and which domains they arrived from. This is not housekeeping.
+§3 associates against the target's maps and checks redundancy against its existing claims, and both read
+whatever happens to be on disk. A clone a few commits behind can have gained principles, graduated the
+very question you were about to attach to, and already hold a near-duplicate of the claim you're
+deriving — none of which surfaces until the push in §6 is rejected, by which point the note is written
+and the association is already wrong.
+
+If the fetch fails, or there is no remote, or git isn't available here, continue — but say so. A skipped
+or failed refresh must never read as "the target is current." State that the association and the
+redundancy check ran against a possibly-stale copy, so the human weighing the proposal knows what it was
+weighed against. An unreported gap that looks exactly like a clean result is the failure this whole flow
+is built to avoid.
+
 ## 2. Derive the candidate
 
 Write the note you would write if you were authoring fresh in the target graph — never move or modify the
@@ -73,7 +88,11 @@ fastest way to see what the claim might connect to. Three outcomes, in order of 
    evidence from a second domain, say so explicitly in the proposal — under the commons' convention that's
    the line between a provisional stance and a held one, and it's worth the reader's attention.
 2. **Attaches to an open question.** No forcing required — questions exist to absorb claims that don't yet
-   support a principle.
+   support a principle. **Confirm the question is still open before attaching to it.** A question that has
+   already graduated is not a valid target: the claim belongs under the attractor it became, as evidence,
+   which is outcome 1. Check this by reading the note itself — whether it still carries `## question` or
+   now carries `## so what` — never by where a map happens to list it. Questions graduate in place, so a
+   map can still file one under a "questions" heading long after it stopped being one.
 3. **Nothing fits.** Propose a new question, not a new attractor. Attractors earn their name from
    accumulated evidence; a promotion may create one when the material genuinely warrants it (a fresh commons
    with nothing to attach to yet), but the default for a first-of-its-kind claim is a question.
@@ -126,5 +145,14 @@ changelog line — name the paths, don't blanket-stage) and push if a remote exi
 promotion is invisible to every other machine and session — the cross-domain chain this skill exists for
 dies in a working tree. If the push is blocked (no network, permission rule), say so plainly so the
 human knows the promotion hasn't left this clone.
+
+**A rejected push means the target moved while you were writing.** Pull and rebase, then push again — but
+read what came in before resolving anything. If the incoming commits touch what the association rests on
+— the question you attached to, the attractor you added evidence to, the map line you inserted — stop and
+re-derive rather than resolving mechanically. A conflict in a map is rarely a merge chore; it usually
+means the association is now wrong: the question graduated, an attractor absorbed the claim, or someone
+else's promotion already said this. Take it back through §3 and re-propose. Resolving by hand and pushing
+produces a promotion that is well-formed and pointed at the wrong thing, which is far harder to find
+later than the conflict was.
 
 A promoted note must stand alone. That's the whole test, at every step of this flow.


### PR DESCRIPTION
Four defects found in real use, plus one new behavior. All four defects share the same shape: **a gap that is indistinguishable from a clean result.** That shape is also why the delta log ships here — a template fix that never propagates leaves the plugin looking correct while every downstream graph stays broken.

## Fix 1 — subagent silence is an error (`process` steps 4, 8, 9)

Found on the first real `/process` run (osu-builder-in-residence, 2026-07-21). All four signal-class subagents completed their reads and went idle **without volunteering findings**. Each needed an explicit follow-up before reporting. Four out of four — a property of the fanout, not a fluke.

A run reading that silence as "nothing found" would assemble a plan from zero findings, write the source note, stamp it `processed:` with an empty `ran:` list, and report a clean sweep. The stamp is what makes re-runs resume instead of redo, so the session gets permanently marked handled and every finding is silently lost. For scale: the four readers had actually produced 3 patterns and 9 observations, including three divergences between the session's self-account and what the transcript showed.

- **Step 4** — an empty or missing return is an error condition to chase, never a null result. A class may be recorded empty only on an explicit "nothing in this class" statement from that reader; silence, an empty message, and a reader that simply stopped are none of them that statement.
- **Step 8** — a non-reporting reader is collected here and named in the run report. It is the one failure with no error message attached, so a collect step that only gathers steps which threw would never mention it.
- **Step 9** — the `processed:` stamp is withheld while any class has neither reported findings nor explicitly reported none. An unstamped partial run is recoverable; a complete-looking stamp over an uninspected class is not.

## Fix 2 — pull the promotion target before the screen runs (`process` step 11)

Found promoting five claims from osu-builders-studio into `~/Developer/commons` (2026-07-21). Step 11's "not already steering" screen read the target graph from the local working copy without fetching. Against a stale copy it cannot see recent claims, so duplicates read as novel — and redundancy detection is the screen's entire job, so stale means decorative.

The refresh now happens **before the screen runs**, not after candidates are derived — the screen runs before the plan is presented, so the ordering is the substance of the fix. It degrades explicitly: no remote, no network, or no git means the screen still runs, but says so rather than letting silence imply the target is current.

## Fix 3 — `promote` §1, §3, §6

Same incident. The local commons clone was **9 commits behind**. In that window it had gained three principles (from zero), ~20 claims, and ~10 questions from two other domains. **Both** questions the claims were being associated to had graduated to principles. At least one claim was a probable duplicate. All five claims were already written and committed before any of this surfaced — it surfaced only because the push was rejected, by which point the two real defects had already happened and left no trace.

- **§1** — fetch and fast-forward before reading the target's config or maps, and say what came in. Degrades gracefully: a failed or skipped fetch must never read as "the target is current."
- **§3** — a graduated question is an invalid association target. Checked by reading the note (`## question` vs `## so what`), not inferred from where a map files it — questions graduate in place, so a map can list one under "questions" long after it stopped being one.
- **§6** — a rejected push means the target moved. Pull, rebase, retry; but if the incoming commits touch what the association rests on, stop and re-derive through §3 rather than resolving mechanically. A map conflict usually means the association is now wrong, not that there's a merge chore.

## New behavior — proactive entity recommendation (`process` steps 4 and 5)

Entity creation was reactive and conditional. The only rule anywhere was *"if the entry names a plugin or skill not yet in `entities/`, add a lookup-only entity note"* — step 6 of an 8-step per-observation workflow in the sibling `knowledge-graph` skill. It fired purely as a side effect of writing an observation that happened to mention a noun.

Two consequences: step 4's inspection had **no entity signal class**, so a named noun the graph keeps returning to was never a finding in its own right; and step 5's plan never surfaced an entity that clearly warranted a note but had no observation attaching to it, so it never reached the approval gate.

- **Step 4** — unnamed entities become a standing signal class, looked for on both the inline and fanout paths, with the mention count carried forward. The SLOT instruction now tells the generator to phrase the class in the domain's own vocabulary rather than hardcoding one.
- **Step 5** — entity recommendations are their own approvable line items, carrying the count: *"this run named X and Y four times each; neither has an entity note; create them?"*

## The delta log

`plugins/knowledge-commons/references/deltas.md` is new, per [`docs/specs/knowledge-commons-patch-mechanism.md`](../blob/main/docs/specs/knowledge-commons-patch-mechanism.md) (D8 and "The delta log"). **This is what carries these fixes to the three already-generated graphs** — `claude-code-plugins`, `wellstead`, `osu-builder-in-residence`. Regenerating them would destroy the local prose they've accumulated; hand-editing three graphs doesn't scale and rots silently.

Six entries at `version: 0.2.0`, all targeting `process` (the file with fully stable anchors — verified, all five anchor strings resolve exactly):

| id | anchor |
|---|---|
| `step4-explicit-negative` | `## 4. Inspect` |
| `step8-collect-nonreporting` | `## 8. Continue-and-collect` |
| `step9-stamp-gate` | `## 9. Stamp` |
| `step11-pull-target` | `## 11. The promotion tail` |
| `step4-entity-signal-class` | `## 4. Inspect` |
| `step5-entity-recommend` | `## 5. Propose the plan` |

**No delta for `promote`** — it's a plugin skill and propagates on plugin update. Only generated, project-owned files need patching.

The preamble states the authoring contract: the seven fields, the rule that a template edit is incomplete without its delta, and the warning that a vague `satisfied-test` silently breaks both redundancy detection (D9, before) and post-application verification (D14, after).

These entries are inert until `/graph-patch` ships in PR 4 — that ordering is deliberate per the spec's execution plan, so the patcher is designed against six real deltas rather than a speculative one.

## Q1 resolved: no `knowledge-graph` delta

The spec's Q1 asks whether the entity change needs a `knowledge-graph` counterpart, and flags that the natural anchor there — `## Extraction Workflow: {source-type}` — is one of two unstable headings.

**Decided: no change, no delta.** Not because the anchor is inconvenient, but because the change doesn't belong there. The two templates already divide labor explicitly — `process` says *when* each thing happens during a run, `knowledge-graph` says *how* to write it. `knowledge-graph`'s step 6 describes how to write an entity note once one is warranted, and it is still correct; nothing about it is wrong. What was missing was any mechanism for deciding an entity is warranted in the first place, which is entirely a *when* concern. A standalone entity note approved at step 5 is already covered on the *how* side by the existing "Capture" workflow and the "Types in This Graph" entry.

That the unstable anchor is thereby avoided is a convenience, not the reason.

## Scope

Touched only: `templates/process.md`, `skills/promote/SKILL.md`, the new `deltas.md`, and both version files (0.1.8 → 0.2.0, matched — minor rather than patch, since the entity change is new behavior). Did not touch `graph-init`, `graph-patch`, or `process.md` section 10 (reserved for the follow-up PR that adds delta 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

