### PR TITLE
feat(knowledge-commons): generate applied-delta state and surface pending patches (0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "knowledge-commons",
       "source": "./plugins/knowledge-commons",
       "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ]
 }

--- a/plugins/knowledge-commons/.claude-plugin/plugin.json
+++ b/plugins/knowledge-commons/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-commons",
   "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -187,4 +187,40 @@ Entries are append-only and ordered by version.
     applicable and the section is correct as it stands. If it does: does the plan present entity
     recommendations as explicit, separately-approvable line items carrying the mention count,
     rather than as a consequence of the observations being written?
+
+- id: step10-pending-patches
+  file: process
+  anchor: "## 10. Report"
+  version: 0.4.0
+  instruction: >
+    Make the run report the place an unpropagated template fix stops being silent: have it suggest
+    the plugin's /graph-patch skill, which reads the current delta log and answers authoritatively
+    whether anything applies. The generated skill must not read the delta log itself and must not
+    assert that patches are pending — it lives in the project and has no path to the plugin, and any
+    plugin path written into it was resolved at generation time, so it names the generating version
+    rather than the installed one. Suggest, never auto-run: /graph-patch edits hand-written prose
+    under per-delta approval. Gate the suggestion on a stated cadence rather than raising it on every
+    run — raise it unconditionally while this project's .commons.yml has no generated: block, since
+    nothing has ever been propagated here and the condition extinguishes itself on the first patch
+    run; raise it only periodically once a block exists, recording that it was raised in the
+    changelog entry this step already writes so a later run can see when it last happened; and raise
+    it whenever the cadence cannot be determined.
+  rationale: >
+    The mechanism's stated goal is to make an unpropagated fix visible rather than silent, and manual
+    invocation was its only discovery path — a maintenance mechanism nobody is ever reminded to run
+    reproduces the failure it was built to prevent. This step already suggests out-of-plan skills
+    rather than auto-running them, so a pending-patch line fits the idiom exactly. The constraint on
+    where the log is read is not incidental. graph-init stamps resolved plugin paths into generated
+    skills, and those are already stale in the wild: two live graphs point at knowledge-commons 0.1.7
+    and 0.1.8 while the plugin is at 0.4.0, resolving today only because those cache directories
+    happen to survive. A discovery hook reading a stale log would report "nothing pending" from it,
+    which is worse than no hook at all — it converts an unnoticed gap into a confirmed clean bill of
+    health. The cadence is part of the fix rather than polish on it: a notice that fires on every run
+    carries no information and gets tuned out, which is the same silence by another route.
+  satisfied-test: >
+    Does the section direct the report to surface pending template patches by suggesting the
+    plugin's /graph-patch skill — rather than by reading the delta log or any other plugin-side file
+    itself, and without claiming to know whether patches are actually pending — and does it state a
+    cadence under which the suggestion is sometimes withheld, rather than raising it unconditionally
+    on every run?
 ```

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -200,11 +200,14 @@ Entries are append-only and ordered by version.
     plugin path written into it was resolved at generation time, so it names the generating version
     rather than the installed one. Suggest, never auto-run: /graph-patch edits hand-written prose
     under per-delta approval. Gate the suggestion on a stated cadence rather than raising it on every
-    run — raise it unconditionally while this project's .commons.yml has no generated: block, since
-    nothing has ever been propagated here and the condition extinguishes itself on the first patch
-    run; raise it only periodically once a block exists, recording that it was raised in the
-    changelog entry this step already writes so a later run can see when it last happened; and raise
-    it whenever the cadence cannot be determined.
+    run, keyed on what is locally observable rather than on what it implies: raise it every run while
+    this project's .commons.yml has no generated: block; raise it about monthly once a block exists;
+    and raise it whenever the cadence cannot be determined. Make the monthly arm durable — have it
+    write a literal, fixed marker string into the changelog entry this step already writes, and have
+    it scan both the live changelog and the most recent monthly archive for that marker. Both halves
+    matter: a free-form note is not reliably recognizable to the run that has to find it, and this
+    graph's changelog rotates monthly, so scanning only the current file re-raises at every month
+    boundary.
   rationale: >
     The mechanism's stated goal is to make an unpropagated fix visible rather than silent, and manual
     invocation was its only discovery path — a maintenance mechanism nobody is ever reminded to run
@@ -222,5 +225,8 @@ Entries are append-only and ordered by version.
     plugin's /graph-patch skill — rather than by reading the delta log or any other plugin-side file
     itself, and without claiming to know whether patches are actually pending — and does it state a
     cadence under which the suggestion is sometimes withheld, rather than raising it unconditionally
-    on every run?
+    on every run? And where that cadence has a periodic arm that suppresses the suggestion based on
+    having raised it before, does the section name a fixed marker string to write and to look for,
+    and require looking in the archived changelog as well as the live one — so the suppression
+    survives the changelog's monthly rotation?
 ```

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -227,6 +227,38 @@ format. If the run surfaced something a skill *outside* the plan could act on, s
 rather than auto-running it. (Generated skills reference each other directly by name; there is no `${CLAUDE_PLUGIN_ROOT}`
 available here, because this skill lives in the project, not in the plugin.)
 
+**Pending template patches belong here too.** This skill was generated from a plugin template and has
+since diverged — you own this file. When the plugin fixes a defect in that template, nothing about the
+fix reaches this file on its own; the plugin's `/graph-patch` skill is what propagates it, and it only
+runs when someone invokes it. This report is where an unpropagated fix stops being silent.
+
+You cannot answer whether anything is actually pending, and must not pretend to. What has been applied
+here is recorded in this project's `.commons.yml` under `generated:`, but what *exists* to apply lives in
+the plugin's delta log — and this skill has no path to the plugin, per the note above. That is
+deliberate, not an oversight to work around: any plugin path written into this file was resolved when
+this file was generated, so it points at the plugin version that generated it, not the one installed now.
+Reading a stale delta log and reporting "nothing pending" from it is worse than reporting nothing at all,
+because it turns an unnoticed gap into a confirmed clean bill of health. `/graph-patch` ships with the
+plugin, always reads the current log, and answers authoritatively. Suggest it; let it answer.
+
+Cadence matters, because a line that appears on every single run carries no information and gets tuned
+out — which fails the same way silence does:
+
+- **No `generated:` block in `.commons.yml`** — `/graph-patch` has never run against this graph, so
+  nothing has ever been propagated into this file. Raise it every run until that changes; the condition
+  extinguishes itself on the first patch run.
+- **A `generated:` block exists** — this graph has been checked at least once, and you have no local
+  evidence either way about since. Raise it roughly monthly: scan the recent changelog for an entry
+  already carrying this note and stay quiet if one falls inside that window, and when you do raise it,
+  say so in the changelog entry you are already writing so the next run can see when it last happened.
+- **Can't tell** — no readable `.commons.yml`, ambiguous changelog — raise it. A redundant suggestion
+  costs a line; the other error is the defect being fixed.
+
+Keep it to a line, and keep it honest — it is a suggestion to check, not a claim that patches are
+waiting: *"This graph hasn't been checked for template patches; `/graph-patch` reads the plugin's current
+delta log and will say whether any apply."* Never auto-run it. It edits prose this project wrote by hand,
+and its approval is per-delta by design.
+
 <!-- SLOT: promotion-tail — CONDITIONAL. Include this entire "## 11" section only if .commons.yml sets
 promotes-to: for this graph. If the graph has no promotes-to:, omit section 11 entirely — do not leave a
 placeholder or an empty header. When included, fill the generalization guidance from interview block 6

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -228,36 +228,28 @@ rather than auto-running it. (Generated skills reference each other directly by 
 available here, because this skill lives in the project, not in the plugin.)
 
 **Pending template patches belong here too.** This skill was generated from a plugin template and has
-since diverged — you own this file. When the plugin fixes a defect in that template, nothing about the
-fix reaches this file on its own; the plugin's `/graph-patch` skill is what propagates it, and it only
-runs when someone invokes it. This report is where an unpropagated fix stops being silent.
+since diverged — you own it — so a fix to that template reaches this file only when someone runs the
+plugin's `/graph-patch`. Suggest it here. Never auto-run it, and never claim to know whether patches are
+pending: what has been applied here is recorded in this project's `.commons.yml` under `generated:`, but
+what *exists* to apply lives in the plugin's delta log, which this skill has no path to and must not go
+looking for — any plugin path written into this file was resolved at generation time and names a version
+that has since moved on. `/graph-patch` always reads the current log; let it answer.
 
-You cannot answer whether anything is actually pending, and must not pretend to. What has been applied
-here is recorded in this project's `.commons.yml` under `generated:`, but what *exists* to apply lives in
-the plugin's delta log — and this skill has no path to the plugin, per the note above. That is
-deliberate, not an oversight to work around: any plugin path written into this file was resolved when
-this file was generated, so it points at the plugin version that generated it, not the one installed now.
-Reading a stale delta log and reporting "nothing pending" from it is worse than reporting nothing at all,
-because it turns an unnoticed gap into a confirmed clean bill of health. `/graph-patch` ships with the
-plugin, always reads the current log, and answers authoritatively. Suggest it; let it answer.
+Cadence, because a line on every run carries no information and gets tuned out:
 
-Cadence matters, because a line that appears on every single run carries no information and gets tuned
-out — which fails the same way silence does:
+- **`.commons.yml` has no `generated:` block** — nothing here records any delta as applied to this file.
+  Raise it every run until a block appears.
+- **A `generated:` block exists** — raise it about monthly. Scan `changelog.md` *and* the most recent
+  `changelog/YYYY-MM.md` archive for the literal marker `[patch-check-suggested]`, and stay quiet if one
+  falls within the last month; when you do raise it, put that exact marker in the changelog entry you are
+  already writing. Both halves are load-bearing: the changelog rotates monthly, so scanning only the
+  current file would re-raise at every month boundary, and a free-form note is not reliably recognizable
+  to the run that has to find it.
+- **Can't tell** — raise it. A redundant line is cheap; the other error is the defect being fixed.
 
-- **No `generated:` block in `.commons.yml`** — `/graph-patch` has never run against this graph, so
-  nothing has ever been propagated into this file. Raise it every run until that changes; the condition
-  extinguishes itself on the first patch run.
-- **A `generated:` block exists** — this graph has been checked at least once, and you have no local
-  evidence either way about since. Raise it roughly monthly: scan the recent changelog for an entry
-  already carrying this note and stay quiet if one falls inside that window, and when you do raise it,
-  say so in the changelog entry you are already writing so the next run can see when it last happened.
-- **Can't tell** — no readable `.commons.yml`, ambiguous changelog — raise it. A redundant suggestion
-  costs a line; the other error is the defect being fixed.
-
-Keep it to a line, and keep it honest — it is a suggestion to check, not a claim that patches are
-waiting: *"This graph hasn't been checked for template patches; `/graph-patch` reads the plugin's current
-delta log and will say whether any apply."* Never auto-run it. It edits prose this project wrote by hand,
-and its approval is per-delta by design.
+Keep it to a line, and keep it a suggestion to check rather than a claim that anything is waiting:
+*"This graph may have template patches pending; `/graph-patch` reads the plugin's current delta log and
+will say whether any apply."*
 
 <!-- SLOT: promotion-tail — CONDITIONAL. Include this entire "## 11" section only if .commons.yml sets
 promotes-to: for this graph. If the graph has no promotes-to:, omit section 11 entirely — do not leave a

--- a/plugins/knowledge-commons/skills/graph-init/SKILL.md
+++ b/plugins/knowledge-commons/skills/graph-init/SKILL.md
@@ -211,10 +211,46 @@ entity and synthesis tiers (when the interview declared them) follow the referen
 and `sinks:` entirely for a graph that has none — don't write empty lists. Do not invent top-level keys
 the spec doesn't name (there is no `feeders:` or similar registry in this design).
 
-One exception matters when you're writing over a config that already exists — the re-run path from step
-1. `generated:` is a legal sixth key owned by `/graph-patch`, holding applied-delta state. It isn't part
-of the interview and won't come from any answer, so a rewrite assembled purely from interview output
-will silently drop it. If the existing file has a `generated:` block, carry it across untouched.
+**Then write a `generated:` block** — the legal sixth key, holding applied-delta state. It records which
+template deltas this project's generated skills already contain, and `/graph-patch` reads it to decide
+what is still pending. Writing it here is what keeps a freshly generated graph out of `/graph-patch`'s
+bootstrap path: the skills you are about to write in step 6 are rendered from the *current* templates, so
+every delta in the log at this version is already baked into them, and recording those ids as applied is
+exactly what stops the patcher from proposing edits the prose already contains. Shape:
+
+```yaml
+generated:
+  process:
+    template-version: <this plugin's version>
+    applied: [<every delta id in the log whose file is process>]
+  knowledge-graph:
+    template-version: <this plugin's version>
+    applied: [<every delta id whose file is knowledge-graph>]
+```
+
+Build it by reading two plugin files at generation time — both resolve for *you*, the generator:
+`${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` for `version`, and
+`${CLAUDE_PLUGIN_ROOT}/references/deltas.md` for the ids, taking every entry whose `file:` matches, in log
+order.
+
+**Read the log; never write the ids from memory.** A list hardcoded into this skill is correct only until
+the next delta is written, and then it is wrong in the direction that doesn't announce itself: the new
+delta gets recorded as already applied in a skill that was generated before it existed, so `/graph-patch`
+treats it as done and never offers it again. That is the silent-loss failure this whole mechanism exists to
+end, reproduced by the generator that feeds it. If the log is missing, or has no entries for a file, write
+`applied: []` — an empty list is a true statement (nothing to apply yet), not a gap.
+
+Write a sub-key only for a skill you actually generate. A graph with no sources gets no `process` skill at
+all (step 6), so the commons carries `knowledge-graph` alone; a `process` sub-key there would claim state
+for a file that doesn't exist. By the same test, `--config-only` writes no `generated:` block whatsoever:
+it generates nothing, and the hand-written skills it wires up never came from these templates, so no delta
+describes a change they are missing.
+
+One exception matters when you're writing over a config that already exists — the re-run path from step 1.
+There, `generated:` is not yours to compute: it reflects patches `/graph-patch` has applied to prose you
+are not regenerating. It isn't part of the interview and won't come from any answer, so a rewrite assembled
+purely from interview output will silently drop it. If the existing file has a `generated:` block, carry it
+across untouched rather than rebuilding it from the log.
 
 ### 5. Scaffold
 

--- a/plugins/knowledge-commons/skills/graph-init/SKILL.md
+++ b/plugins/knowledge-commons/skills/graph-init/SKILL.md
@@ -196,11 +196,21 @@ types:
     - { name: question,  dir: questions/ }
   reference:  { name: reference, dir: reference/ }
 promotes-to: ~/.claude/rules/
+generated:
+  knowledge-graph:
+    template-version: <this plugin's version>
+    applied: [<every delta id in the log whose file is knowledge-graph>]
 ```
 
 No `sources:` and no `sinks:` — the commons never processes anything; everything in it arrives
 by promotion. Scaffold it per step 5 and generate its `knowledge-graph` skill per step 6 — but **not**
 a `process` skill: a graph with no sources has nothing to orchestrate.
+
+`generated:` is the one part of that preset that isn't literal. This path writes the commons config here
+and never enters step 4, so build the block by step 4's rules rather than pasting those two placeholder
+lines: read the version and the delta log, and write the `knowledge-graph` sub-key alone. There is no
+`process` sub-key, because there is about to be no `process` skill — claiming state for a file you are
+deliberately not generating is a lie the patcher would later act on.
 
 ### 4. Write `.commons.yml`
 
@@ -211,10 +221,13 @@ entity and synthesis tiers (when the interview declared them) follow the referen
 and `sinks:` entirely for a graph that has none — don't write empty lists. Do not invent top-level keys
 the spec doesn't name (there is no `feeders:` or similar registry in this design).
 
-**Then write a `generated:` block** — the legal sixth key, holding applied-delta state. It records which
-template deltas this project's generated skills already contain, and `/graph-patch` reads it to decide
-what is still pending. Writing it here is what keeps a freshly generated graph out of `/graph-patch`'s
-bootstrap path: the skills you are about to write in step 6 are rendered from the *current* templates, so
+**On a fresh write — and only on a fresh write — also write a `generated:` block**, the legal sixth key
+holding applied-delta state. The re-run path is different and is handled at the end of this step; read that
+before writing the block over a config that already exists.
+
+The block records which template deltas this project's generated skills already contain, and
+`/graph-patch` reads it to decide what is still pending. Writing it here is what keeps a freshly
+generated graph out of `/graph-patch`'s bootstrap path: the skills you are about to write in step 6 are rendered from the *current* templates, so
 every delta in the log at this version is already baked into them, and recording those ids as applied is
 exactly what stops the patcher from proposing edits the prose already contains. Shape:
 
@@ -240,17 +253,43 @@ treats it as done and never offers it again. That is the silent-loss failure thi
 end, reproduced by the generator that feeds it. If the log is missing, or has no entries for a file, write
 `applied: []` — an empty list is a true statement (nothing to apply yet), not a gap.
 
-Write a sub-key only for a skill you actually generate. A graph with no sources gets no `process` skill at
-all (step 6), so the commons carries `knowledge-graph` alone; a `process` sub-key there would claim state
-for a file that doesn't exist. By the same test, `--config-only` writes no `generated:` block whatsoever:
-it generates nothing, and the hand-written skills it wires up never came from these templates, so no delta
-describes a change they are missing.
+`template-version` means *generated at* when you write it. When `/graph-patch` later updates it, it means
+*patched through* — the highest delta version it actually stamped. Those two coincide today and will
+diverge the first time the plugin bumps a version carrying no new deltas. That's harmless and worth
+knowing rather than fixing: `applied:` is the source of truth in both directions, and the patcher selects
+by set membership on ids, never by comparing version numbers.
 
-One exception matters when you're writing over a config that already exists — the re-run path from step 1.
-There, `generated:` is not yours to compute: it reflects patches `/graph-patch` has applied to prose you
-are not regenerating. It isn't part of the interview and won't come from any answer, so a rewrite assembled
-purely from interview output will silently drop it. If the existing file has a `generated:` block, carry it
-across untouched rather than rebuilding it from the log.
+Order: this block is written here, in step 4, before step 6 writes the skills it describes. That is the
+opposite of the ordering `/graph-patch` uses (it stamps only what verifiably landed), and the divergence
+is deliberate. A run that dies between step 4 and step 6 leaves a config claiming state for skills that
+don't exist — loud, and repaired by re-running the generator. Writing the block after step 6 instead would
+mean a run that dies mid-generation leaves generated skills with no record at all, which looks exactly
+like a pre-mechanism graph and lands in `/graph-patch`'s 0.1.8 bootstrap at the wrong version. Prefer the
+failure that shows.
+
+Write a sub-key only for a skill you actually generate — a sub-key for a file you don't write claims state
+the patcher will later act on. In practice this step generates both, so both appear here; the sourceless
+case is the commons, whose config is written on step 3's own path with a `knowledge-graph` sub-key alone.
+By the same test, `--config-only` writes no `generated:` block whatsoever: it generates nothing, and the
+hand-written skills it wires up never came from these templates, so no delta describes a change they are
+missing.
+
+**The re-run path is the exception** — writing over a config that already exists, from step 1. A re-run
+does **not** regenerate the skills, so the premise that justifies the block above is false here: nothing is
+being rendered from current templates, and the state of the existing skills is not something this run
+knows. `generated:` is not yours to compute on this path, in either of its two cases:
+
+- **The existing file has a `generated:` block** — carry it across **untouched**. It records patches
+  `/graph-patch` applied to prose you are not regenerating. It isn't part of the interview and won't come
+  from any answer, so a rewrite assembled purely from interview output silently drops it.
+- **The existing file has no `generated:` block** — write **none**. Do not fall back to the fresh-write
+  instruction above. This is the live case, not a hypothetical: every graph generated before this
+  mechanism existed has no block, so a re-run there would read the log and stamp every delta in it as
+  applied to skills that contain not one of them. `/graph-patch` would then report nothing pending,
+  permanently. That is the same silent loss the "never write the ids from memory" paragraph warns about,
+  reached by a different route — and it is worse, because it is written against skills the run never
+  looked at. Leave those graphs to `/graph-patch`'s bootstrap, which assumes `0.1.8` and is correct for
+  them by construction.
 
 ### 5. Scaffold
 


### PR DESCRIPTION
Completes the two items the patch-mechanism spec deferred out of #65, #66 and #67. Both were left owned by no open PR, which meant D11 — the spec's own answer to *"make an unpropagated fix visible rather than silent"* — was unimplemented.

## Item 1 — D7: `graph-init` writes the `generated:` block at generation time

`/graph-patch` currently bootstraps missing state by assuming plugin version `0.1.8` (D6). That is true by construction for the three graphs generated before the mechanism existed, but every *new* graph should be born with accurate state instead.

Step 4 of `graph-init` now writes a `generated:` block alongside the rest of `.commons.yml`. The reasoning that makes it correct: a freshly generated skill is rendered from the *current* templates, so every delta at or below the current version is already baked into it — recording them as applied is what stops `/graph-patch` from proposing edits the prose already contains.

**The id list is read, never hardcoded.** The generator reads `${CLAUDE_PLUGIN_ROOT}/references/deltas.md` at generation time and takes every entry whose `file:` matches, plus `.claude-plugin/plugin.json` for the version. A list frozen into the skill would be correct only until the seventh delta was written, and then wrong in the direction that doesn't announce itself: the new delta recorded as already applied in a skill generated before it existed, so `/graph-patch` treats it as done and never offers it again — the exact silent-loss failure this mechanism exists to end, reproduced by the generator that feeds it.

Two edge cases handled: the `process` sub-key is omitted for a sourceless graph (the commons gets no `process` skill), and `--config-only` writes no block at all (it generates nothing, and the hand-written skills it wires up never came from these templates). The re-run path still carries an existing block across untouched rather than rebuilding it from the log.

`graph-init` already sanctioned `generated:` as a legal key at both its `Never` bullet and step 4, from #65 — this implements what those permit.

## Item 2 — delta 7: the D11 discovery hook

`templates/process.md` step 10 (Report) now surfaces pending template patches, and `deltas.md` carries the matching `step10-pending-patches` entry at 0.4.0.

### The path-resolution constraint that shaped it

The obvious implementation — have the generated skill read the delta log — is broken, and verifiably so.

The generated `process` skill lives in the *project*, not the plugin, and has no `${CLAUDE_PLUGIN_ROOT}`. `graph-init` handles this elsewhere by stamping a resolved absolute path at generation time. Those stamped paths are pinned to the generating plugin version and are **already stale in the wild**: `claude-code-plugins`' generated skill points at `.../knowledge-commons/0.1.7/...` and `osu-builder-in-residence`' at `0.1.8`, while the plugin is now at 0.4.0. They resolve today only because those old cache directories happen still to exist.

So the generated skill must not read the delta log by path. A stamped path would make it read a stale log — or fail outright once that cache directory is reclaimed — and a discovery mechanism that reports *"nothing pending"* from a stale log is worse than no discovery mechanism at all: it converts an unnoticed gap into a confirmed clean bill of health.

The shape chosen instead uses step 10's existing idiom (*"if the run surfaced something a skill outside the plan could act on, suggest it in the report rather than auto-running it"*). The report **suggests** `/graph-patch` and explicitly disclaims knowing whether anything is pending. `/graph-patch` is a plugin skill: always current, always reading the live log, able to answer authoritatively. A weaker mechanism that works beats a stronger one reading a stale log.

Nothing added here gives the generated skill a plugin path — verified: the template's only `${CLAUDE_PLUGIN_ROOT}` mention remains the pre-existing note explaining that there isn't one.

### Cadence

A suggestion on literally every run is noise that gets tuned out, which defeats the purpose as surely as silence does. Three tiers, all decidable from project-local artifacts:

- **No `generated:` block in `.commons.yml`** — `/graph-patch` has never run here, so nothing has ever been propagated into this file. Raise it every run. The condition is self-extinguishing: the first patch run writes the block and it stops firing.
- **A `generated:` block exists** — checked at least once, with no local evidence either way about since. Raise it roughly monthly, using the changelog this step already writes as the record of when it last fired. No new state, no new `.commons.yml` key.
- **Can't tell** — raise it. A redundant suggestion costs a line; the other error is the defect being fixed.

## Verification

- `## 10. Report` resolves to exactly one heading in the template **and** in all three live graphs (`claude-code-plugins`, `wellstead`, `osu-builder-in-residence`) — including osu's 371-line divergence against the 208-line template.
- `deltas.md` parses as YAML; 7 entries; the new one carries all seven fields at `version: 0.4.0`.
- Both version files parse as valid JSON and match at 0.4.0.
- Both edited files re-read start to finish for coherence.

Minor bump per `.claude/rules/plugin-updates.md`: both items are new capability, not fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)