### PR TITLE
fix(knowledge-commons): split graph-init Q9 so a half-answer can't pass as complete

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "knowledge-commons",
       "source": "./plugins/knowledge-commons",
       "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-      "version": "0.4.0"
+      "version": "0.4.1"
     }
   ]
 }

--- a/plugins/knowledge-commons/.claude-plugin/plugin.json
+++ b/plugins/knowledge-commons/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-commons",
   "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/knowledge-commons/skills/graph-init/SKILL.md
+++ b/plugins/knowledge-commons/skills/graph-init/SKILL.md
@@ -96,9 +96,15 @@ it comes up, not as a seventh block.
      the last branch, and it needs an actual answer to get there, never merely an empty search. In
      config-only mode there is nothing to create — see that mode's handling.
 
-**Block 2 — Types.** This block has five questions and so needs **two** `AskUserQuestion` calls —
-questions 5 through 7, then 8 and 9. Don't try to fit it into one; question 9 is the one that gets
-lost, and its answer shapes both the source tiers and whether a synthesis tier exists at all.
+**Block 2 — Types.** This block has six questions and so needs **two** `AskUserQuestion` calls —
+questions 5 through 7, then 8, 9, and 9b. Don't try to fit it into one; the tail of this block is what
+gets lost, and 9 and 9b shape the source tiers and whether a synthesis tier exists at all.
+
+**9 and 9b are deliberately separate questions.** They were one question joined by "and" until a real
+run showed why that fails: the tool returns one answer per question, so a reader who answers the first
+half leaves the second unanswered, and the generator fills the silence with an assumption. That is the
+same silent-loss shape as dropping the question outright, just harder to notice — the answer looks
+present. Never recombine them to save a slot; both calls have room.
 5. What does this domain call its evidence type — the atomic, provenanced note (e.g. `observation`,
    `claim`)?
 6. What attractor types does it need? For each, is it *open* (accumulates evidence, no verdict —
@@ -107,9 +113,11 @@ lost, and its answer shapes both the source tiers and whether a synthesis tier e
    say none.
 8. Does this graph need a reference tier for unbounded lookup facts that are never an association
    surface?
-9. Are there source tiers whose raw material must be preserved verbatim, distinct from the types
-   above? And do any rich bounded sources (a call, a meeting) warrant an intermediate *synthesis* note
-   between the source and its evidence — one note distilling the event before atomic extraction?
+9. Are there source tiers whose raw material must be preserved verbatim, distinct from the types above?
+   A transcript, a recording, an original document — material where the distillation is not a substitute
+   for the thing itself.
+9b. Do any rich bounded sources — a call, a meeting, a session — warrant an intermediate *synthesis*
+   note between the source and its evidence: one note distilling the event before atomic extraction?
 
 **Block 3 — Sources.**
 10. What arrives on its own, without being asked for — a chronicle directory and glob, pasted URLs,


### PR DESCRIPTION
## The problem

Q9 asked two separate things joined by "and":

1. Are there source tiers whose raw material must be preserved **verbatim**?
2. Do rich bounded sources warrant an intermediate **synthesis** note?

`AskUserQuestion` returns one answer per question. A reader who answers the first half leaves the second unanswered, and the generator fills the silence with an assumption instead of asking again.

This is the same silent-loss shape as the dropped-question bug fixed in #65, one level down and harder to catch — the answer *looks* present. The skill's own preamble already conceded both halves are load-bearing: "its answer shapes both the source tiers and whether a synthesis tier exists at all."

## Not hypothetical

On the run that surfaced the original bug, the damage came through exactly this clause structure. The generator answered the synthesis half unilaterally — writing "This graph declares no synthesis tier" into the generated skill — and the verbatim half is the session-transcript question, which was excluded on the generator's own "(Recommended)" marking. A parallel session reached the opposite conclusion with the user's endorsement.

## The change

Splits Q9 into 9 and 9b, each asking one thing, and adds a note stating why they must stay separate so a future editor doesn't recombine them to save a slot.

Numbering 1–20 stays intact — several cross-references in this file cite blocks and questions by number. Block 2 already spends two `AskUserQuestion` calls; both now carry three questions, under the cap of four.

**No delta entry.** `graph-init` is a plugin skill and propagates on plugin update, unlike the generated skills the delta log serves.

Patch bump to 0.4.1: this corrects a defect and adds no capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)