### PR TITLE
fix(knowledge-commons): recommend entity TYPES, not entity notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "knowledge-commons",
       "source": "./plugins/knowledge-commons",
       "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-      "version": "0.4.1"
+      "version": "0.5.0"
     }
   ]
 }

--- a/docs/specs/knowledge-commons-patch-mechanism.md
+++ b/docs/specs/knowledge-commons-patch-mechanism.md
@@ -287,6 +287,14 @@ is written (see Q1).
 > They are replaced by a single entry, `step10-entity-type-gap` (`## 10. Report`, version 0.5.0), which is
 > deliberately *not* conditional on the graph already declaring an entity type. The table above is left as
 > the record of the initial batch as it shipped.
+>
+> **One generation window is worth noting.** A graph generated while the template carried the entity slots
+> — plugin versions 0.2.0 through 0.4.1 — keeps that instance-level prose in its steps 4 and 5 permanently,
+> since removing a slot from the template does not reach an already-generated skill, and it would also
+> receive `step10-entity-type-gap`, ending up carrying both layers. None of the three known graphs is
+> affected: none was generated in that window. The plugin is published, so an unknown graph could exist;
+> the remedy there is a hand edit to steps 4 and 5, not a delta, since a delta that removes prose is
+> outside what the log expresses.
 
 All seven target `process`, which is the file with fully stable anchors. That is fortunate rather than
 designed; Q1 is where it stops being true.
@@ -351,6 +359,14 @@ workflow). Settle when writing PR 3 — and note the constraint: the natural anc
 targeting it would resolve in `claude-code-plugins`, miss in `osu` (renamed to bare `## Extraction
 Workflow`), and be ambiguous in `wellstead` (three such headings). If PR 3 needs that anchor, the
 mechanism needs a story for multi-match and near-match before it can carry it.
+
+> **Moot as posed, 2026-07-22 (plugin 0.5.0).** "The entity change" here means deltas 5 and 6, which were
+> the wrong layer and have been removed (see the superseded note under the initial-batch table). Their
+> replacement, `step10-entity-type-gap`, recommends a *type* rather than a note, targets `## 10. Report`
+> — a stable anchor — and touches `knowledge-graph` not at all, so it raises no counterpart question. The
+> unstable-anchor constraint below is unaffected and still the live concern: it is a fact about
+> `## Extraction Workflow: {source-type}` across the three graphs, not about the entity change, and the
+> first delta that needs that anchor will still need a multi-match and near-match story.
 
 **Q2. Delta ids are hand-authored and must be globally unique forever.** No collision check is proposed.
 Low risk at current scale; worth a thought if the log grows past a few dozen entries.

--- a/docs/specs/knowledge-commons-patch-mechanism.md
+++ b/docs/specs/knowledge-commons-patch-mechanism.md
@@ -279,6 +279,15 @@ delta. It ships in PR 4 alongside the mechanism.
 Deltas 5 and 6 may also warrant a `knowledge-graph` counterpart — to be settled when that template change
 is written (see Q1).
 
+> **Superseded 2026-07-22 (plugin 0.5.0).** Deltas 5 and 6 were built at the wrong layer of abstraction:
+> they recommended entity *notes* for individual un-noted nouns, where the request was for new entity
+> *types* — entries in `.commons.yml`'s `entity:` list. Both were removed from the log rather than
+> superseded within it, which the append-only convention permits here only because no graph had recorded
+> them as applied (no live `.commons.yml` carried a `generated:` block, so nothing downstream was stamped).
+> They are replaced by a single entry, `step10-entity-type-gap` (`## 10. Report`, version 0.5.0), which is
+> deliberately *not* conditional on the graph already declaring an entity type. The table above is left as
+> the record of the initial batch as it shipped.
+
 All seven target `process`, which is the file with fully stable anchors. That is fortunate rather than
 designed; Q1 is where it stops being true.
 

--- a/plugins/knowledge-commons/.claude-plugin/plugin.json
+++ b/plugins/knowledge-commons/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-commons",
   "description": "Generator for per-project knowledge graphs with cross-domain promotion: scaffolds a graph, a /process pipeline, and project-owned skills from a config-driven interview; promotes portable claims into a personal commons; propagates template fixes into already-generated skills",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": {
     "name": "Derek DeHart"
   },

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -190,17 +190,26 @@ Entries are append-only and ordered by version.
     one category, named as things a reader would look up, none covered by a declared type; the
     graph's existing notes may supply corroborating instances where one run is thin. (c) The
     report names the category and the instances evidencing it, so the reader judges from evidence
-    rather than assertion. (d) Recommending is not doing: point at the work — a .commons.yml
-    entry, a directory, a map, backfill — and name re-interviewing graph-init's block 2 as the
-    sanctioned route for changing declared types. This step must never edit .commons.yml itself;
-    that file belongs to graph-init and /graph-patch, and a schema change must not ride a per-run
-    plan approval, which is why this lives in the report and not in the plan.
+    rather than assertion. (d) Recommending is not doing: point at the work and name re-interviewing
+    graph-init's block 2 as the sanctioned route for changing declared types. Describe that work for
+    both cases the inversion in (a) creates — where an entity: list already exists it is a new entry
+    plus a directory, a map, and backfill; where there is none it is *establishing* the tier, which
+    is the larger ask and must be said rather than assumed away. This step must never edit
+    .commons.yml itself. Attribute that file to graph-init only: /graph-patch amends the generated:
+    block and guarantees every other key survives byte-identical, so naming it as an owner of the
+    entity: list sends a reader to a skill that will correctly refuse.
     Gate it on a cadence rather than raising it every run, in the same shape this section already
-    uses for pending template patches: write a literal marker naming the category into the
-    changelog entry this step already writes, and before raising a category scan both the live
-    changelog and the most recent monthly changelog archive for that marker with that category.
-    Suppression is per-category so a different gap still surfaces, and it expires when the marker
-    rotates out of both files, letting a still-recurring category be raised again.
+    uses for pending template patches: write a marker naming the category into the changelog entry
+    this step already writes, and before raising a category scan both the live changelog and the most
+    recent monthly changelog archive for it. The marker's *prefix* is the fixed, literal part — the
+    category name inside it is prose the raising run chooses — so the scan matches the prefix, reads
+    the categories already recorded, and decides sameness by meaning rather than by string equality.
+    That distinction is the substance of the cadence, not a refinement of it: nothing constrains how
+    successive runs word a category, so a literal whole-marker match lets "MCP servers" and "MCP
+    server integrations" read as different gaps and re-raises the same one every run, with each run
+    looking locally correct. Suppression is per-category so a genuinely different gap still surfaces,
+    and it expires when the marker rotates out of both files, letting a still-recurring category be
+    raised again.
   rationale: >
     The requested capability was "proactively identify and recommend new entities where they are
     relevant to the graph." It was first built at the instance level — noticing individual nouns
@@ -222,9 +231,14 @@ Entries are append-only and ordered by version.
     unconditional on the graph already having an entity type (a section that applies this only
     when an entity tier exists, or that proposes lookup notes for un-noted nouns, does NOT satisfy
     this test); it must set a recurrence bar over multiple distinct instances rather than firing on
-    a single mention; it must name the category and its evidencing instances; it must stop at
-    recommending, pointing at the .commons.yml / directory / map work and at graph-init's block-2
-    re-interview rather than editing the config; and it must state a cadence that suppresses a
-    category already raised, using a fixed marker looked for in both the live and the archived
-    changelog.
+    a single mention; it must name the category and its evidencing instances; and it must stop at
+    recommending, pointing at graph-init's block-2 re-interview rather than editing the config, and
+    describing the work for a graph with no entity: list (establish the tier) as well as for one that
+    has it (add an entry). Two further things it must NOT say: that /graph-patch owns or may change
+    the entity: list, and that the suppression marker is matched literally in whole — the test for
+    the cadence is whether the section fixes only the marker's *prefix*, has the scan read the
+    categories already recorded under it in both the live and the archived changelog, and decide
+    whether the category is the same one by meaning rather than by string equality. A section that
+    scans for the whole marker including a free-form category name fails this test, because nothing
+    holds that name stable between runs.
 ```

--- a/plugins/knowledge-commons/references/deltas.md
+++ b/plugins/knowledge-commons/references/deltas.md
@@ -133,61 +133,6 @@ Entries are append-only and ordered by version.
     screen runs, and require saying so explicitly whenever the copy did not reach the remote's
     tip — including when a fetch succeeds but the fast-forward is refused?
 
-- id: step4-entity-signal-class
-  file: process
-  anchor: "## 4. Inspect"
-  version: 0.2.0
-  instruction: >
-    APPLIES ONLY IF this graph declares an entity type in .commons.yml. The entity tier is
-    optional — a graph whose interview answered "none" has no entity type, no scaffolded entity
-    directory, and no map to enter one in. For such a graph this delta does not apply: report it
-    as not applicable and propose no edit.
-    Where it does apply: make entity recognition a first-class inspection concern: named nouns
-    this graph tracks that have no entity note yet are a finding in their own right, not a side
-    effect of writing an observation that mentions one. Both the inline-read path and the
-    subagent-fanout path look for them, and both carry the mention count forward to the plan. Add
-    an unnamed-entities class to this graph's signal-class list, phrased in the domain's own
-    vocabulary for the nouns it tracks.
-  rationale: >
-    Entity creation was reactive and conditional — the only rule anywhere was "if the entry names
-    a plugin or skill not yet in entities/, add a lookup-only entity note," buried as one step of
-    the sibling knowledge-graph skill's per-observation workflow. It fired only as a side effect
-    of writing an observation that happened to mention a noun. With no entity signal class,
-    inspection had no way to treat a named noun the graph keeps returning to as a finding at all,
-    so an entity clearly worth a note but with nothing attaching to it was invisible to the run.
-    The mention count is what lets the plan make the case at step 5.
-  satisfied-test: >
-    First, does this graph declare an entity type in .commons.yml? If not, the delta is not
-    applicable and the section is correct as it stands. If it does: does inspection treat unnamed
-    entities — nouns the graph tracks with no entity note yet — as a signal class of their own,
-    found on both the inline and fanout paths, independently of whether any observation in the
-    run attaches to them?
-
-- id: step5-entity-recommend
-  file: process
-  anchor: "## 5. Propose the plan"
-  version: 0.2.0
-  instruction: >
-    APPLIES ONLY IF this graph declares an entity type in .commons.yml — same applicability test
-    as step4-entity-signal-class, and the two travel together: apply both or neither. For a graph
-    with no entity tier, report not applicable and propose no edit; a plan that recommends
-    entities there proposes writes into a directory that was never scaffolded.
-    Where it applies: the plan surfaces entity recommendations as their own line items — naming
-    the noun, its mention count for this run, and that it has no entity note yet — rather than
-    folding them into the notes that mention them. Shape: "this run named X and Y four times
-    each; neither has an entity note; create them?"
-  rationale: >
-    Companion to step4-entity-signal-class: step 4 finds the entity, step 5 is where the human
-    gets to approve it. Without an explicit line item, an entity that plainly warrants a note but
-    has no observation attaching to it never reaches the approval gate, so the finding is
-    discarded at exactly the point it was supposed to become actionable. The count is what makes
-    the case reviewable — the reader judges from the evidence rather than from an assertion.
-  satisfied-test: >
-    First, does this graph declare an entity type in .commons.yml? If not, the delta is not
-    applicable and the section is correct as it stands. If it does: does the plan present entity
-    recommendations as explicit, separately-approvable line items carrying the mention count,
-    rather than as a consequence of the observations being written?
-
 - id: step10-pending-patches
   file: process
   anchor: "## 10. Report"
@@ -229,4 +174,57 @@ Entries are append-only and ordered by version.
     having raised it before, does the section name a fixed marker string to write and to look for,
     and require looking in the archived changelog as well as the live one — so the suppression
     survives the changelog's monthly rotation?
+
+- id: step10-entity-type-gap
+  file: process
+  anchor: "## 10. Report"
+  version: 0.5.0
+  instruction: >
+    Have the run report recommend a new entity *type* — a new entry in .commons.yml's entity:
+    list — when the run keeps naming a category of thing the graph has no declared type for.
+    This is about the schema, not about missing notes for nouns of a type that already exists.
+    Four properties are the substance of it. (a) It is NOT conditional on the graph already
+    declaring an entity type: a graph whose interview answered "none" is exactly the graph that
+    may need its first one, so gating on an existing entity tier disables the check where it
+    matters most. (b) The bar is recurrence, not a single sighting: several distinct instances of
+    one category, named as things a reader would look up, none covered by a declared type; the
+    graph's existing notes may supply corroborating instances where one run is thin. (c) The
+    report names the category and the instances evidencing it, so the reader judges from evidence
+    rather than assertion. (d) Recommending is not doing: point at the work — a .commons.yml
+    entry, a directory, a map, backfill — and name re-interviewing graph-init's block 2 as the
+    sanctioned route for changing declared types. This step must never edit .commons.yml itself;
+    that file belongs to graph-init and /graph-patch, and a schema change must not ride a per-run
+    plan approval, which is why this lives in the report and not in the plan.
+    Gate it on a cadence rather than raising it every run, in the same shape this section already
+    uses for pending template patches: write a literal marker naming the category into the
+    changelog entry this step already writes, and before raising a category scan both the live
+    changelog and the most recent monthly changelog archive for that marker with that category.
+    Suppression is per-category so a different gap still surfaces, and it expires when the marker
+    rotates out of both files, letting a still-recurring category be raised again.
+  rationale: >
+    The requested capability was "proactively identify and recommend new entities where they are
+    relevant to the graph." It was first built at the instance level — noticing individual nouns
+    that lacked an entity note and proposing notes for them — and shipped at 0.2.0 as the deltas
+    step4-entity-signal-class and step5-entity-recommend. That was the wrong layer of abstraction.
+    The entity: list in .commons.yml holds *types* (plugin, skill), and graph-init's block 2
+    question asks the user to name types, not instances. So "recommend new entities" means noticing
+    that the material keeps naming a *kind* of thing the graph has no type for — a schema gap, not
+    a missing note. The two instance-level deltas were removed rather than superseded: no graph had
+    applied them in any durable state (no live .commons.yml carried a generated: block), so nothing
+    downstream had recorded them, and the append-only convention exists to protect what a graph has
+    already recorded as applied. This entry is the corrected one, and the run report is the surface
+    because a schema recommendation is an observation for a human to act on later rather than a
+    write for this run to approve.
+  satisfied-test: >
+    Does the section have the run report recommend adding a new entity TYPE to .commons.yml — as
+    distinct from recommending notes for individual nouns of an existing type — when the run
+    repeatedly names a category that no declared type covers? The recommendation must be
+    unconditional on the graph already having an entity type (a section that applies this only
+    when an entity tier exists, or that proposes lookup notes for un-noted nouns, does NOT satisfy
+    this test); it must set a recurrence bar over multiple distinct instances rather than firing on
+    a single mention; it must name the category and its evidencing instances; it must stop at
+    recommending, pointing at the .commons.yml / directory / map work and at graph-init's block-2
+    re-interview rather than editing the config; and it must state a cadence that suppresses a
+    category already raised, using a fixed marker looked for in both the live and the archived
+    changelog.
 ```

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -100,30 +100,11 @@ Neither is an empty message, nor a reader that simply stopped. Chase it — foll
 class's findings, and ask again if the second reply is no better. If it still won't report, the class
 has failed, not come back empty; route it into step 8.
 
-<!-- SLOT: entity-inspection — CONDITIONAL. Include the paragraph below only if .commons.yml declares an
-entity type. Block 2's entity question is answerable with "none," and a graph that answered so has no
-entity type, no scaffolded entity directory, and no map to enter one in — so there is nothing for this
-paragraph to write into. Omit it entirely rather than leaving it to hunt for notes that have nowhere to
-go. It travels with the entity-recommendation slot in step 5: keep both or drop both, they are one
-feature. -->
-
-Inspection also looks for **entities** — the named nouns this graph keeps returning to that don't have an
-entity note yet. Treat this as a finding in its own right rather than a side effect of writing something
-else: a noun the input names repeatedly earns a note whether or not any observation in this run happens
-to attach to it. Both paths look for them, and both carry the count of mentions forward — step 5 needs it
-to make the case.
-
 <!-- SLOT: signal-classes — the signal classes inspection looks for, per tier, from interview block 3
 ("what signal classes should inspection look for"). Name each class plainly (what it is, what a finding
 in that class looks like) so both the inline-read path and the subagent-fanout path use the same
-vocabulary. Keep it to what this domain actually has classes for — don't invent classes to fill space.
-One further class is standing rather than domain-derived, and CONDITIONAL on the same test as the
-entity-inspection slot above: if .commons.yml declares an entity type, add an unnamed-entities class,
-phrased in this domain's own vocabulary for the nouns it tracks, so the fanout has a reader assigned to
-it like any other class. If the interview answered "none" to entities, omit that class — there is no
-entity tier for its findings to land in. -->
-    Example (orchard, chronicle tier — three domain classes, plus the entity class because orchard
-    declares an entity type):
+vocabulary. Keep it to what this domain actually has classes for — don't invent classes to fill space. -->
+    Example (orchard, chronicle tier — three domain classes):
     - **Decisions.** A choice was made and a reason given — becomes a `decision` attractor or evidence
       for an existing one.
     - **Recurring friction.** The same kind of problem shows up again, named or not — becomes a
@@ -131,8 +112,6 @@ entity tier for its findings to land in. -->
     - **Standalone observations.** True and useful on their own, not yet clustering with anything —
       becomes an `observation` with no attractor yet; note it as unattached in the plan rather than
       forcing a link.
-    - **Unnamed entities.** A grove, cultivar, or tool the entry keeps returning to that has no note
-      under `entities/` — becomes a lookup-only entity note, on the strength of the mentions alone.
 
 ## 5. Propose the plan
 
@@ -140,17 +119,6 @@ Lay out, per skill/note, what will be created and what will be updated — and j
 being skipped and why (already captured, too operational, not durable — see the sibling
 `knowledge-graph` skill's conventions). Present it as `[y / edit / explain]`. One approval gates the
 entire run; there is no per-note confirmation after this point except the re-pause condition in step 6.
-
-<!-- SLOT: entity-recommendation — CONDITIONAL, on the same test as step 4's entity-inspection slot:
-include the paragraph below only if .commons.yml declares an entity type. Keep both or drop both — a plan
-that recommends entities for a graph with no entity tier proposes writes into a directory that was never
-scaffolded. -->
-
-**Entity recommendations get their own line items**, naming the noun, how many times this run named it,
-and that it has no entity note yet — not folded into the notes that happen to mention it. An entity that
-plainly warrants a note but has no observation attaching to it surfaces no other way, so if it isn't a
-line in the plan you never get the chance to approve it. Give the count and let the reader judge; a
-declined entity costs one skip at review.
 
 ## 6. Run to completion
 
@@ -250,6 +218,38 @@ Cadence, because a line on every run carries no information and gets tuned out:
 Keep it to a line, and keep it a suggestion to check rather than a claim that anything is waiting:
 *"This graph may have template patches pending; `/graph-patch` reads the plugin's current delta log and
 will say whether any apply."*
+
+**A missing entity *type* belongs here too.** Not a missing note — a missing *kind*. If this run kept
+naming a category of thing that this graph has no declared type for, say so here. It surfaces in the
+report rather than in the plan because it is a schema change, not a note: `.commons.yml`'s `entity:`
+list belongs to `graph-init` and `/graph-patch`, never to this skill, and a change to the graph's shape
+should not ride a per-run plan approval meant for the notes this run is writing.
+
+**This is not conditional on the graph already declaring an entity type.** A graph whose interview
+answered "none" is precisely the graph that may discover it needs its first one — gating the check on an
+entity tier already existing would make the check unable to find the case it matters most for.
+
+**The bar is recurrence, not a single sighting.** What earns a type is several *distinct* instances of
+one category — named things a reader would plausibly look up — with no declared type covering any of
+them. One passing mention of one noun is not a schema gap. Where a single run is thin evidence, the
+graph's own record counts: earlier notes naming the same category strengthen the case.
+
+Name the category and the instances that evidence it, so the reader can judge rather than take the
+recommendation on trust — *"this run named three MCP servers by name; no declared type covers them."*
+Then point at the work instead of doing any of it: a new entry in `.commons.yml`'s `entity:` list, a
+directory for it, a map, and whatever backfill the existing notes want. `graph-init`'s sanctioned route
+for changing declared types is re-interviewing block 2 of its interview; name that as the path. This
+step recommends; it does not edit `.commons.yml` and does not create the tier.
+
+Cadence, on the same reasoning as the patch suggestion above — a recommendation that repeats every run
+stops being read. When you raise a category, write the literal marker `[entity-type-gap: <category>]`
+into the changelog entry you are already writing, using the same category name you used in the report.
+Before raising one, scan `changelog.md` *and* the most recent `changelog/YYYY-MM.md` archive for that
+marker with that category, and stay quiet if it is there. Suppression is per-category, so a second,
+different gap still surfaces while the first is suppressed. It also expires on its own: once the marker
+rotates out of both files the category may be raised again — which is the behavior you want, because a
+category still recurring months after it was first raised has earned a second mention, and one that
+stopped recurring never clears the bar again.
 
 <!-- SLOT: promotion-tail — CONDITIONAL. Include this entire "## 11" section only if .commons.yml sets
 promotes-to: for this graph. If the graph has no promotes-to:, omit section 11 entirely — do not leave a

--- a/plugins/knowledge-commons/references/templates/process.md
+++ b/plugins/knowledge-commons/references/templates/process.md
@@ -222,8 +222,8 @@ will say whether any apply."*
 **A missing entity *type* belongs here too.** Not a missing note — a missing *kind*. If this run kept
 naming a category of thing that this graph has no declared type for, say so here. It surfaces in the
 report rather than in the plan because it is a schema change, not a note: `.commons.yml`'s `entity:`
-list belongs to `graph-init` and `/graph-patch`, never to this skill, and a change to the graph's shape
-should not ride a per-run plan approval meant for the notes this run is writing.
+list belongs to `graph-init`, never to this skill, and a change to the graph's shape should not ride a
+per-run plan approval meant for the notes this run is writing.
 
 **This is not conditional on the graph already declaring an entity type.** A graph whose interview
 answered "none" is precisely the graph that may discover it needs its first one — gating the check on an
@@ -236,20 +236,29 @@ graph's own record counts: earlier notes naming the same category strengthen the
 
 Name the category and the instances that evidence it, so the reader can judge rather than take the
 recommendation on trust — *"this run named three MCP servers by name; no declared type covers them."*
-Then point at the work instead of doing any of it: a new entry in `.commons.yml`'s `entity:` list, a
-directory for it, a map, and whatever backfill the existing notes want. `graph-init`'s sanctioned route
-for changing declared types is re-interviewing block 2 of its interview; name that as the path. This
-step recommends; it does not edit `.commons.yml` and does not create the tier.
+Then point at the work instead of doing any of it. Where this graph already has an `entity:` list in
+`.commons.yml`, the work is a new entry in it, a directory for it, a map, and whatever backfill the
+existing notes want. Where there is no `entity:` list at all — the graph answered "none" when it was
+set up — the recommendation is to *establish* the tier rather than add to it, which is the larger of
+the two asks and worth saying plainly. Either way the route is the same: `graph-init`'s sanctioned way
+to change declared types is re-interviewing block 2 of its interview, so name that as the path. This
+step recommends; it does not edit `.commons.yml`, does not add the entry, and does not create the tier.
 
 Cadence, on the same reasoning as the patch suggestion above — a recommendation that repeats every run
-stops being read. When you raise a category, write the literal marker `[entity-type-gap: <category>]`
-into the changelog entry you are already writing, using the same category name you used in the report.
-Before raising one, scan `changelog.md` *and* the most recent `changelog/YYYY-MM.md` archive for that
-marker with that category, and stay quiet if it is there. Suppression is per-category, so a second,
-different gap still surfaces while the first is suppressed. It also expires on its own: once the marker
-rotates out of both files the category may be raised again — which is the behavior you want, because a
-category still recurring months after it was first raised has earned a second mention, and one that
-stopped recurring never clears the bar again.
+stops being read. When you raise a category, write a marker of the form `[entity-type-gap: <category>]`
+into the changelog entry you are already writing, using the category name you used in the report.
+Before raising one, scan `changelog.md` *and* the most recent `changelog/YYYY-MM.md` archive for the
+literal prefix `[entity-type-gap:`, read the category names already recorded there, and stay quiet if
+any of them is *the same category* as the one you are about to raise. Judge that by meaning, not by
+string match: nothing constrains how a given run words a category, so "MCP servers" one month and "MCP
+server integrations" the next are one gap already raised, and matching literally would re-raise it
+every run while each run looked locally correct. The fixed prefix is what makes the record findable;
+recognizing the category is judgment, of the same kind this skill exercises everywhere else.
+
+Suppression is per-category, so a second, genuinely different gap still surfaces while the first is
+suppressed. It also expires on its own: once the marker rotates out of both files the category may be
+raised again — which is the behavior you want, because a category still recurring months after it was
+first raised has earned a second mention, and one that stopped recurring never clears the bar again.
 
 <!-- SLOT: promotion-tail — CONDITIONAL. Include this entire "## 11" section only if .commons.yml sets
 promotes-to: for this graph. If the graph has no promotes-to:, omit section 11 entirely — do not leave a


### PR DESCRIPTION
## The layer error

The ask was that generated pipelines "proactively identify and recommend new entities where they're relevant to the graph." That shipped at 0.2.0 as **instance-level** recognition: notice an individual noun (a specific plugin, a specific skill) with no entity *note*, and propose a note for it.

That's the wrong layer. `.commons.yml`'s `entity:` list holds **types**:

```yaml
  entity:
    - { name: plugin, dir: entities/ }
    - { name: skill,  dir: entities/ }
```

And `graph-init` Q7 — *"Are there entities worth lookup-only notes — the nouns worth a name but no synthesis? **Name them** or say none"* — is asking for types. So "recommend new entities" means: notice that the material keeps naming a *kind* of thing this graph has no type for, and recommend adding that type. That's a schema gap, not a missing note.

Concretely: this repo's graph declares `plugin` and `skill`. If chronicles kept naming agents, hooks, or MCP servers as lookup-worthy things with no home type, the pipeline should say so.

## What changed

**Removed from `templates/process.md`** — the `entity-inspection` SLOT and prose (step 4), the `entity-recommendation` SLOT and prose (step 5), and the entity signal class from the `signal-classes` SLOT instruction and its orchard example. Everything else in those steps is untouched: `step4-explicit-negative`'s silence-is-not-an-empty-class prose and step 5's plan mechanics both survive.

**Added to step 10 (the run report).** The report is the deliberate surface: a schema change is not a note the plan writes, and it should not ride a per-run plan approval meant for this run's notes. It sits alongside the pending-template-patches suggestion, which is already handled the same way — an observation the human acts on later.

## The not-conditional inversion

The deltas being replaced were **gated on the graph already declaring an entity type** — they reported "not applicable" for a graph that answered "none" to Q7. The new one inverts that: it is explicitly **not conditional**. A graph with no entity tier is precisely the graph that might discover it needs its *first* type, so gating on an existing tier disables the check exactly where it matters most.

Other settled points: the bar is **recurrence** (several distinct instances of one category, not one passing mention of one noun); the report **names the category and its evidencing instances** so the reader can judge; and **recommending is not doing** — it points at the `.commons.yml` entry, directory, and map, and names re-interviewing `graph-init`'s block 2 as the sanctioned route. `/process` never edits `.commons.yml`.

**Cadence.** Suppression mirrors the pending-patch mechanism already in that section: raising a category writes the literal marker `[entity-type-gap: <category>]` into the changelog entry step 10 already writes, and a category is skipped if that marker is found in the live changelog or the most recent monthly archive. Suppression is per-category (a second, different gap still surfaces) and self-expiring (once the marker rotates out of both files the category may be raised again — a category still recurring months later has earned a second mention; one that stopped recurring never clears the bar again).

## Why in-place delta replacement is safe here

The delta log is append-only by convention, and a shipped delta normally must be superseded rather than rewritten. That convention exists to protect **what a graph has already recorded as applied**. Nothing has:

```
$ grep -c "^generated:" ~/Developer/{claude-code-plugins,wellstead,osu-builder-in-residence}/.commons.yml
0
0
0
```

No live graph carries a `generated:` block, so deltas 5 and 6 were never stamped anywhere. They are removed and replaced by one entry, `step10-entity-type-gap` (anchor `## 10. Report`, version 0.5.0). Two deltas sharing an anchor is already normal — `step10-pending-patches` targets the same one, as `## 4. Inspect` previously carried two.

The `satisfied-test` is written to fail against the *old* instance-level text, not just against a silent section — a graph that had somehow applied the old version must not read as already satisfied.

`docs/specs/knowledge-commons-patch-mechanism.md` gets a superseded note under its initial-batch table; the table itself is left as the record of what shipped.

## Verification

- `## 10. Report` matches exactly once in the template and in all three live graphs' `process/SKILL.md`.
- `deltas.md` parses; 6 entries, all seven fields each; the new one at `0.5.0`, the surviving five unchanged at their original versions.
- Template: 7 SLOT opens / 7 comment closes, no stray braces beyond the pre-existing intentional ones.
- Both version files at `0.5.0`, valid JSON. Minor, not patch — this replaces one capability with a different one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)